### PR TITLE
Update follow-redirects to 1.14.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "vscode-azurecontainerapps",
             "version": "0.0.1-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -72,7 +73,6 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-9.0.0.tgz",
             "integrity": "sha512-vm9lwosH34Ofl6pM++kD/oLeANYmPt2OQoxNDPyQwSwmPFCshYoxOhLDCzFTbXe2UYAdXVMlgXS+981MP0rJpw==",
-            "license": "MIT",
             "dependencies": {
                 "@azure/core-auth": "^1.1.4",
                 "@azure/ms-rest-azure-js": "^2.1.0",
@@ -80,7 +80,6 @@
                 "tslib": "^1.10.0"
             }
         },
-<<<<<<< HEAD
         "node_modules/@azure/arm-containerregistry": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-8.1.1.tgz",
@@ -103,8 +102,6 @@
                 "tslib": "^1.10.0"
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/@azure/arm-resources": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
@@ -127,20 +124,6 @@
                 "tslib": "^1.10.0"
             }
         },
-<<<<<<< HEAD
-=======
-        "node_modules/@azure/arm-resources-subscriptions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.0.tgz",
-            "integrity": "sha512-OXfeYR4fi2XwHYxd9fFxTQi6VIJcZ8Soec+/yg1m0UL9SpwXoZ1tqLZAVdxba62jL9cpm6HUiQ9+7iQf1BIMrw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/@azure/arm-storage": {
             "version": "15.3.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
@@ -166,21 +149,16 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
             "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
-<<<<<<< HEAD
-=======
-            "dev": true,
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
             "dependencies": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
                 "tslib": "^1.10.0"
             }
         },
-<<<<<<< HEAD
         "node_modules/@azure/container-registry": {
-            "version": "1.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.5.tgz",
-            "integrity": "sha512-i6paEU7PX4L3CwVe5CD+IWtoj1H6SHvi6c71WKZqrbHsZJ36q3o1xlIOekrYU1ZJwaswlWf03j3u1rlGtHjbAA==",
+            "version": "1.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.6.tgz",
+            "integrity": "sha512-EVpEFzmJjXjh9RLwEGz94erNyM0hW+XeNj0TGvstsI5iaYB1PY0iprqyci1InrMyNd8Qmt2Ww6a1cjlS45/3+A==",
             "dependencies": {
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-client": "^1.0.0",
@@ -194,25 +172,11 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/container-registry/node_modules/@azure/core-tracing": {
-            "version": "1.0.0-preview.13",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-            "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.0.1",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@azure/container-registry/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/@azure/core-asynciterator-polyfill": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
@@ -236,9 +200,9 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/core-client": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.1.tgz",
-            "integrity": "sha512-7IHm2DGg2u7dJYtCW84Ik7uENHfE8VsM/sWloZezPKYDoWZrg7JzwjvdGAfsaELKi2p0GE+JBaAbDYnNpr5V1w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.2.tgz",
+            "integrity": "sha512-qfkRYKmeEmisluMdGTbBtXeyBLaImjFeVW0gcT5yRAwxJmlnTvSyD+a3PjukAtjIrl/tnb4WSJOBpONSJ91+5Q==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-asynciterator-polyfill": "^1.0.0",
@@ -251,24 +215,11 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/core-client/node_modules/@azure/core-tracing": {
-            "version": "1.0.0-preview.13",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-            "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.0.1",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@azure/core-client/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-<<<<<<< HEAD
         "node_modules/@azure/core-paging": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.0.tgz",
@@ -286,12 +237,10 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.1.tgz",
-            "integrity": "sha512-xTQiv47O5cWzJFkwiDrUTT4K4IYbUIts0gaou5TZxAAuhQi9kAKWHEmFTjHVMOeAmyDhlMM5cb21M2n4WDto1A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.2.tgz",
+            "integrity": "sha512-kymICKESeHBpVLgQiAxllgWdSTopkqtmfPac8ITwMCxNEC6hzbSpqApYbjzxbBNkBMgoD4GESo6LLhR/sPh6kA==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -307,42 +256,17 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
-            "version": "1.0.0-preview.13",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-            "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.0.1",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/core-tracing": {
-            "version": "1.0.0-preview.12",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
-            "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
+            "version": "1.0.0-preview.13",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+            "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
             "dependencies": {
-                "@opentelemetry/api": "^1.0.0",
+                "@opentelemetry/api": "^1.0.1",
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -383,23 +307,16 @@
                 "keytar": "^7.3.0"
             }
         },
-        "node_modules/@azure/identity/node_modules/jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+        "node_modules/@azure/identity/node_modules/@azure/core-tracing": {
+            "version": "1.0.0-preview.12",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
+            "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
             "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
+                "@opentelemetry/api": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/@azure/identity/node_modules/open": {
@@ -422,18 +339,16 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-<<<<<<< HEAD
         "node_modules/@azure/loganalytics": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
             "integrity": "sha512-rOALuRVTQFn04znlt+BGWIAQltnmrsj3BccGOYBUtcNo/ZC+klgn1rZD0t1+CZmCRcG8UeIddq+88wHP1SF/bQ==",
+            "deprecated": "This package is deprecated in favor of @azure/monitor-query which works both on node.js and browsers",
             "dependencies": {
                 "@azure/ms-rest-js": "^2.4.0",
                 "tslib": "^1.9.3"
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/@azure/logger": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -479,6 +394,19 @@
                 "tunnel": "0.0.6",
                 "uuid": "^8.3.2",
                 "xml2js": "^0.4.19"
+            }
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
             }
         },
         "node_modules/@azure/ms-rest-nodeauth": {
@@ -533,12 +461,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -676,9 +604,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
         "node_modules/@microsoft/eslint-config-azuretools": {
@@ -782,9 +710,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "7.28.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-            "integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+            "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -829,9 +757,9 @@
             "dev": true
         },
         "node_modules/@types/glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
             "dev": true,
             "dependencies": {
                 "@types/minimatch": "*",
@@ -884,14 +812,14 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.17.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.21.tgz",
-            "integrity": "sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA=="
+            "version": "14.17.33",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
         },
         "node_modules/@types/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
             "dev": true
         },
         "node_modules/@types/source-list-map": {
@@ -968,9 +896,9 @@
             "dev": true
         },
         "node_modules/@types/webpack": {
-            "version": "4.41.31",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.31.tgz",
-            "integrity": "sha512-/i0J7sepXFIp1ZT7FjUGi1eXMCg8HCCzLJEQkKsOtbJFontsJLolBcDC+3qxn5pPwiCt1G0ZdRmYRzNBtvpuGQ==",
+            "version": "4.41.32",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
+            "integrity": "sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -1055,6 +983,24 @@
             },
             "peerDependencies": {
                 "eslint": "*"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "engines": {
+                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
+            },
+            "peerDependencies": {
+                "eslint": ">=5"
             }
         },
         "node_modules/@typescript-eslint/parser": {
@@ -1418,6 +1364,27 @@
                 "node": ">= 0.6.15"
             }
         },
+        "node_modules/adal-node/node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/adal-node/node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/adal-node/node_modules/uuid": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1560,7 +1527,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/archy": {
             "version": "1.0.0",
@@ -1572,7 +1539,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
             "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -1940,6 +1907,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -1953,13 +1921,12 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "optional": true
+            ]
         },
         "node_modules/big-integer": {
-            "version": "1.6.49",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
-            "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
             "dev": true,
             "engines": {
                 "node": ">=0.6"
@@ -2010,7 +1977,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -2021,7 +1988,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -2072,16 +2039,16 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
-            "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+            "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
             "dev": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001264",
-                "electron-to-chromium": "^1.3.857",
+                "caniuse-lite": "^1.0.30001280",
+                "electron-to-chromium": "^1.3.896",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.77",
-                "picocolors": "^0.2.1"
+                "node-releases": "^2.0.1",
+                "picocolors": "^1.0.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2098,6 +2065,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2112,7 +2080,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -2194,6 +2161,15 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/cacache/node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/cacache/node_modules/mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -2257,9 +2233,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001265",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+            "version": "1.0.30001280",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
+            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -2368,13 +2344,10 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "devOptional": true
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -2515,32 +2488,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2753,7 +2700,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
@@ -2763,6 +2710,12 @@
             "dependencies": {
                 "safe-buffer": "~5.1.1"
             }
+        },
+        "node_modules/convert-source-map/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/copy-descriptor": {
             "version": "0.1.1",
@@ -2873,9 +2826,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -2946,7 +2899,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
             "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "mimic-response": "^2.0.0"
             },
@@ -2958,7 +2911,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "optional": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -3087,15 +3040,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/del/node_modules/pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/del/node_modules/rimraf": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -3120,7 +3064,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/denodeify": {
             "version": "1.2.1",
@@ -3141,7 +3085,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "optional": true,
+            "devOptional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
             },
@@ -3289,9 +3233,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.862",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.862.tgz",
-            "integrity": "sha512-o+FMbCD+hAUJ9S8bfz/FaqA0gE8OpCCm58KhhGogOEqiA1BLFSoVYLi+tW+S/ZavnqBn++n0XZm7HQiBVPs8Jg==",
+            "version": "1.3.897",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.897.tgz",
+            "integrity": "sha512-nRNZhAZ7hVCe75jrCUG7xLOqHMwloJMj6GEXEzY4OMahRGgwerAo+ls/qbqUwFH+E20eaSncKkQ4W8KP5SOiAg==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -3585,12 +3529,13 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
-            "integrity": "sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
+            "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
             "dev": true,
             "dependencies": {
                 "debug": "^3.2.7",
+                "find-up": "^2.1.0",
                 "pkg-dir": "^2.0.0"
             },
             "engines": {
@@ -3607,24 +3552,22 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.24.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
-            "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
+            "version": "2.25.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
+            "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
             "dev": true,
             "dependencies": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flat": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flat": "^1.2.5",
                 "debug": "^2.6.9",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.6",
-                "eslint-module-utils": "^2.6.2",
-                "find-up": "^2.0.0",
+                "eslint-module-utils": "^2.7.1",
                 "has": "^1.0.3",
-                "is-core-module": "^2.6.0",
+                "is-core-module": "^2.8.0",
+                "is-glob": "^4.0.3",
                 "minimatch": "^3.0.4",
-                "object.values": "^1.1.4",
-                "pkg-up": "^2.0.0",
-                "read-pkg-up": "^3.0.0",
+                "object.values": "^1.1.5",
                 "resolve": "^1.20.0",
                 "tsconfig-paths": "^3.11.0"
             },
@@ -3632,7 +3575,7 @@
                 "node": ">=4"
             },
             "peerDependencies": {
-                "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
+                "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
             }
         },
         "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -3676,33 +3619,6 @@
             }
         },
         "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-utils": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
@@ -3717,13 +3633,22 @@
                 "url": "https://github.com/sponsors/mysticatea"
             }
         },
-        "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/eslint/node_modules/ignore": {
@@ -3784,9 +3709,9 @@
             }
         },
         "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "engines": {
                 "node": ">=4.0"
@@ -3805,9 +3730,9 @@
             }
         },
         "node_modules/esrecurse/node_modules/estraverse": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "engines": {
                 "node": ">=4.0"
@@ -4002,7 +3927,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "optional": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4534,9 +4459,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+            "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
             "dev": true
         },
         "node_modules/flush-write-stream": {
@@ -4550,9 +4475,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -4590,16 +4515,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 6"
             }
         },
         "node_modules/fragment-cache": {
@@ -4618,7 +4543,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -4721,7 +4646,7 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -4737,33 +4662,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "optional": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "optional": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4772,7 +4671,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -4840,7 +4739,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/glob": {
             "version": "7.2.0",
@@ -5244,9 +5143,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-            "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+            "version": "13.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+            "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -5438,7 +5337,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/has-value": {
             "version": "1.0.0",
@@ -5524,10 +5423,16 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+            "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/html-to-text": {
             "version": "5.1.1",
@@ -5681,9 +5586,9 @@
             }
         },
         "node_modules/husky": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-            "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true,
             "bin": {
                 "husky": "lib/bin.js"
@@ -5699,6 +5604,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -5712,13 +5618,12 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "optional": true
+            ]
         },
         "node_modules/ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -6022,9 +5927,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-            "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -6140,12 +6045,15 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "devOptional": true,
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-glob": {
@@ -6416,9 +6324,9 @@
             }
         },
         "node_modules/jest-worker": {
-            "version": "27.2.5",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
-            "integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
+            "version": "27.3.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
+            "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -6523,6 +6431,25 @@
                 "npm": ">=1.4.28"
             }
         },
+        "node_modules/jsonwebtoken/node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/jsonwebtoken/node_modules/semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6538,9 +6465,9 @@
             "dev": true
         },
         "node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
             "dependencies": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -6548,11 +6475,11 @@
             }
         },
         "node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
             "dependencies": {
-                "jwa": "^1.4.1",
+                "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -6560,8 +6487,8 @@
             "version": "7.7.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
             "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+            "devOptional": true,
             "hasInstallScript": true,
-            "optional": true,
             "dependencies": {
                 "node-addon-api": "^3.0.0",
                 "prebuild-install": "^6.0.0"
@@ -6590,9 +6517,9 @@
             }
         },
         "node_modules/lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+            "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
             "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.5"
@@ -6694,18 +6621,40 @@
             "dev": true
         },
         "node_modules/load-json-file": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/load-json-file/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/load-json-file/node_modules/strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "dependencies": {
+                "is-utf8": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/loader-runner": {
@@ -6718,9 +6667,9 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -6763,12 +6712,6 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
@@ -7186,19 +7129,19 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.50.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-            "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.33",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-            "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+            "version": "2.1.34",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
             "dependencies": {
-                "mime-db": "1.50.0"
+                "mime-db": "1.51.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -7217,7 +7160,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
             "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "optional": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             },
@@ -7332,7 +7275,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/mocha": {
             "version": "8.4.0",
@@ -7531,6 +7474,15 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/mocha/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/mocha/node_modules/js-yaml": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
@@ -7615,6 +7567,20 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/mocha/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7680,9 +7646,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/msal": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.14.tgz",
-            "integrity": "sha512-k8M5+/jbfSQoCf7CyQzBP5HE5mY8TkBujykLGTEp2x0MvOK/FQsfUTNis28zlvvPVzhgrhb5GQiGM8rRpXyHdA==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.15.tgz",
+            "integrity": "sha512-H/CxkeZJ4laEK6GZ/cDKQoYjBTvDNFK3hDC8mfU8IkuZvKFfFdo9KM89r8spXY7xnBK9SQBAjIuQgwUogeUw7g==",
             "dependencies": {
                 "tslib": "^1.9.3"
             },
@@ -7759,7 +7725,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
             "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -7783,7 +7749,7 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
             "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "semver": "^5.4.1"
             }
@@ -7792,7 +7758,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "optional": true,
+            "devOptional": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -7801,12 +7767,12 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/node-fetch": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-            "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -7815,9 +7781,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "1.1.77",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
-            "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+            "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
             "dev": true
         },
         "node_modules/normalize-package-data": {
@@ -7831,6 +7797,12 @@
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
             }
+        },
+        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
         },
         "node_modules/normalize-package-data/node_modules/semver": {
             "version": "5.7.1",
@@ -7878,7 +7850,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -8143,9 +8115,9 @@
             }
         },
         "node_modules/open": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.3.0.tgz",
-            "integrity": "sha512-7INcPWb1UcOwSQxAXTnBJ+FxVV4MPs/X++FWWBtgY69/J5lc+tCteMt/oFK1MnkyHC4VILLa9ntmwKTwDR4Q9w==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -8299,16 +8271,15 @@
             }
         },
         "node_modules/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "dependencies": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "^1.2.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/parse-node-version": {
@@ -8453,9 +8424,9 @@
             "dev": true
         },
         "node_modules/picocolors": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "node_modules/picomatch": {
@@ -8471,12 +8442,12 @@
             }
         },
         "node_modules/pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/pinkie": {
@@ -8512,18 +8483,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8537,7 +8496,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
             "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -8558,16 +8517,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/prebuild-install/node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "optional": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
             }
         },
         "node_modules/prelude-ls": {
@@ -8621,10 +8570,10 @@
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "node_modules/pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "devOptional": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -8639,6 +8588,16 @@
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
                 "pump": "^2.0.0"
+            }
+        },
+        "node_modules/pumpify/node_modules/pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "node_modules/punycode": {
@@ -8696,7 +8655,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -8711,7 +8670,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "optional": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8729,42 +8688,78 @@
             }
         },
         "node_modules/read-pkg": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "dependencies": {
-                "load-json-file": "^4.0.0",
+                "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "path-type": "^1.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/read-pkg-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "dependencies": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "dependencies": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "dependencies": {
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/read-pkg/node_modules/path-type": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "dependencies": {
-                "pify": "^3.0.0"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/read-pkg/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/readable-stream": {
@@ -8781,6 +8776,12 @@
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
             }
+        },
+        "node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "devOptional": true
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -9062,9 +9063,23 @@
             }
         },
         "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/safe-regex": {
             "version": "1.1.0",
@@ -9258,6 +9273,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -9271,14 +9287,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "optional": true
+            ]
         },
         "node_modules/simple-get": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
             "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -9309,6 +9324,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/snapdragon": {
@@ -9579,9 +9603,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-            "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
             "dev": true
         },
         "node_modules/split-string": {
@@ -9739,18 +9763,44 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "devOptional": true,
             "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "devOptional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "devOptional": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/string.prototype.trimend": {
@@ -9844,13 +9894,12 @@
             }
         },
         "node_modules/table": {
-            "version": "6.7.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-            "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+            "version": "6.7.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
+            "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^8.0.1",
-                "lodash.clonedeep": "^4.5.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.3",
@@ -9861,9 +9910,9 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "8.6.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-            "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.0.tgz",
+            "integrity": "sha512-L+cJ/+pkdICMueKR6wIx3VP2fjIx3yAhuvadUv/osv9yFD7OVZy442xFF+Oeu3ZvmhBGQzoF6mTSt+LUWBmGQg==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -9876,11 +9925,34 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/table/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/table/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
+        },
+        "node_modules/table/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/tapable": {
             "version": "1.1.3",
@@ -9912,7 +9984,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -9920,27 +9992,11 @@
                 "tar-stream": "^2.1.4"
             }
         },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "optional": true
-        },
-        "node_modules/tar-fs/node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "optional": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -9956,7 +10012,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -9964,6 +10020,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/tar/node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/tar/node_modules/mkdirp": {
@@ -9979,38 +10044,28 @@
             }
         },
         "node_modules/tas-client": {
-            "version": "0.1.21",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.21.tgz",
-            "integrity": "sha512-7UuIwOXarCYoCTrQHY5n7M+63XuwMC0sVUdbPQzxqDB9wMjIW0JF39dnp3yoJnxr4jJUVhPtvkkXZbAD0BxCcA==",
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.26.tgz",
+            "integrity": "sha512-o9wYpOwf1jhIose0ArEeW/Zr2T/XZnCKDrNXsCiZ/ctpg0DliU76tJ1rbBGlrOvjzLrMY1S3QwZWOAaF7+5HDw==",
             "dependencies": {
-                "axios": "^0.21.1"
+                "axios": "^0.22.0"
             }
         },
-        "node_modules/terser": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-            "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
-            "dev": true,
+        "node_modules/tas-client/node_modules/axios": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
+            "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
             "dependencies": {
-                "commander": "^2.20.0",
-                "source-map": "~0.7.2",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
+                "follow-redirects": "^1.14.4"
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
-            "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
+            "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
             "dev": true,
             "dependencies": {
                 "jest-worker": "^27.0.6",
-                "p-limit": "^3.1.0",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
@@ -10038,20 +10093,25 @@
                 }
             }
         },
-        "node_modules/terser-webpack-plugin/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+        "node_modules/terser-webpack-plugin/node_modules/acorn": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
             "dev": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "acorn": "bin/acorn"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.4.0"
             }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
             "version": "6.0.0",
@@ -10062,13 +10122,32 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+        "node_modules/terser-webpack-plugin/node_modules/terser": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+            "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^2.20.0",
+                "source-map": "~0.7.2",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "acorn": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "acorn": {
+                    "optional": true
+                }
+            }
         },
-        "node_modules/terser/node_modules/source-map": {
+        "node_modules/terser-webpack-plugin/node_modules/terser/node_modules/source-map": {
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
@@ -10554,7 +10633,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -10610,9 +10689,9 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -10988,9 +11067,9 @@
             }
         },
         "node_modules/vsce": {
-            "version": "1.100.1",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.1.tgz",
-            "integrity": "sha512-1VjLyse5g6e2eQ6jUpslu7IDq44velwF8Jy8s7ePdwGNuG8EzfmaOfVyig3ZSMJ0l8DiJmZllx5bRAB4RMdnHg==",
+            "version": "1.103.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.103.1.tgz",
+            "integrity": "sha512-98oKQKKRp7J/vTIk1cuzom5cezZpYpRHs3WlySdsrTCrAEipB/HvaPTc4VZ3hGZHzHXS9P5p2L0IllntJeXwiQ==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -11000,6 +11079,7 @@
                 "denodeify": "^1.2.1",
                 "glob": "^7.0.6",
                 "hosted-git-info": "^4.0.2",
+                "keytar": "^7.7.0",
                 "leven": "^3.1.0",
                 "lodash": "^4.17.15",
                 "markdown-it": "^10.0.0",
@@ -11017,7 +11097,7 @@
                 "yazl": "^2.2.2"
             },
             "bin": {
-                "vsce": "out/vsce"
+                "vsce": "vsce"
             },
             "engines": {
                 "node": ">= 10"
@@ -11080,18 +11160,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/hosted-git-info": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-            "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/vsce/node_modules/semver": {
@@ -11410,7 +11478,6 @@
                 "vscode-tas-client": "^0.1.22"
             }
         },
-<<<<<<< HEAD
         "node_modules/vscode-azureextensionui/node_modules/@azure/arm-resources": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
@@ -11421,8 +11488,6 @@
                 "tslib": "^1.10.0"
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -11453,11 +11518,11 @@
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
         },
         "node_modules/vscode-tas-client": {
-            "version": "0.1.22",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.22.tgz",
-            "integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.27.tgz",
+            "integrity": "sha512-wyYSdbaSoInXmaXVO54ihvmG6uoRIQ4TdVctJgYqf66oTvUq6e5F3XgtiYRSM6yaqhI0rPqPrYIzLNOO524Z9A==",
             "dependencies": {
-                "tas-client": "0.1.21"
+                "tas-client": "0.1.26"
             },
             "engines": {
                 "vscode": "^1.19.1"
@@ -11497,9 +11562,9 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "node_modules/webpack": {
-            "version": "5.58.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.1.tgz",
-            "integrity": "sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==",
+            "version": "5.64.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.1.tgz",
+            "integrity": "sha512-b4FHmRgaaAjP+aVOVz41a9Qa5SmkUPQ+u8FntTQ1roPHahSComB6rXnLwc976VhUY4CqTaLu5mCswuHiNhOfVw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -11525,7 +11590,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "webpack-sources": "^3.2.2"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -11544,9 +11609,9 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
-            "integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
@@ -11560,7 +11625,6 @@
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
                 "rechoir": "^0.7.0",
-                "v8-compile-cache": "^2.2.0",
                 "webpack-merge": "^5.7.3"
             },
             "bin": {
@@ -11684,9 +11748,9 @@
             }
         },
         "node_modules/webpack/node_modules/webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
+            "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==",
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
@@ -11747,49 +11811,6 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
-        "node_modules/wide-align/node_modules/ansi-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-            "devOptional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "devOptional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/wide-align/node_modules/string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "devOptional": true,
-            "dependencies": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/wide-align/node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "devOptional": true,
-            "dependencies": {
-                "ansi-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/wildcard": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
@@ -11829,32 +11850,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11978,9 +11973,9 @@
             }
         },
         "node_modules/yargs-unparser/node_modules/camelcase": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+            "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -11999,168 +11994,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
-            "dependencies": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/load-json-file": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
-            "dependencies": {
-                "error-ex": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
-            "dependencies": {
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
-            "dependencies": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "dependencies": {
-                "is-utf8": "^0.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/yargs/node_modules/yargs-parser": {
@@ -12241,7 +12074,6 @@
                 "tslib": "^1.10.0"
             }
         },
-<<<<<<< HEAD
         "@azure/arm-containerregistry": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-8.1.1.tgz",
@@ -12264,8 +12096,6 @@
                 "tslib": "^1.10.0"
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "@azure/arm-resources": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
@@ -12288,20 +12118,6 @@
                 "tslib": "^1.10.0"
             }
         },
-<<<<<<< HEAD
-=======
-        "@azure/arm-resources-subscriptions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.0.tgz",
-            "integrity": "sha512-OXfeYR4fi2XwHYxd9fFxTQi6VIJcZ8Soec+/yg1m0UL9SpwXoZ1tqLZAVdxba62jL9cpm6HUiQ9+7iQf1BIMrw==",
-            "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "@azure/arm-storage": {
             "version": "15.3.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
@@ -12327,10 +12143,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
             "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
-<<<<<<< HEAD
-=======
-            "dev": true,
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
             "requires": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -12338,9 +12150,9 @@
             }
         },
         "@azure/container-registry": {
-            "version": "1.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.5.tgz",
-            "integrity": "sha512-i6paEU7PX4L3CwVe5CD+IWtoj1H6SHvi6c71WKZqrbHsZJ36q3o1xlIOekrYU1ZJwaswlWf03j3u1rlGtHjbAA==",
+            "version": "1.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.6.tgz",
+            "integrity": "sha512-EVpEFzmJjXjh9RLwEGz94erNyM0hW+XeNj0TGvstsI5iaYB1PY0iprqyci1InrMyNd8Qmt2Ww6a1cjlS45/3+A==",
             "requires": {
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-client": "^1.0.0",
@@ -12351,15 +12163,6 @@
                 "tslib": "^2.2.0"
             },
             "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.0-preview.13",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-                    "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-                    "requires": {
-                        "@opentelemetry/api": "^1.0.1",
-                        "tslib": "^2.2.0"
-                    }
-                },
                 "tslib": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -12389,9 +12192,9 @@
             }
         },
         "@azure/core-client": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.1.tgz",
-            "integrity": "sha512-7IHm2DGg2u7dJYtCW84Ik7uENHfE8VsM/sWloZezPKYDoWZrg7JzwjvdGAfsaELKi2p0GE+JBaAbDYnNpr5V1w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.2.tgz",
+            "integrity": "sha512-qfkRYKmeEmisluMdGTbBtXeyBLaImjFeVW0gcT5yRAwxJmlnTvSyD+a3PjukAtjIrl/tnb4WSJOBpONSJ91+5Q==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-asynciterator-polyfill": "^1.0.0",
@@ -12401,15 +12204,6 @@
                 "tslib": "^2.2.0"
             },
             "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.0-preview.13",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-                    "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-                    "requires": {
-                        "@opentelemetry/api": "^1.0.1",
-                        "tslib": "^2.2.0"
-                    }
-                },
                 "tslib": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -12417,7 +12211,6 @@
                 }
             }
         },
-<<<<<<< HEAD
         "@azure/core-paging": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.0.tgz",
@@ -12434,12 +12227,10 @@
                 }
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "@azure/core-rest-pipeline": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.1.tgz",
-            "integrity": "sha512-xTQiv47O5cWzJFkwiDrUTT4K4IYbUIts0gaou5TZxAAuhQi9kAKWHEmFTjHVMOeAmyDhlMM5cb21M2n4WDto1A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.2.tgz",
+            "integrity": "sha512-kymICKESeHBpVLgQiAxllgWdSTopkqtmfPac8ITwMCxNEC6hzbSpqApYbjzxbBNkBMgoD4GESo6LLhR/sPh6kA==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -12452,25 +12243,6 @@
                 "uuid": "^8.3.0"
             },
             "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.0-preview.13",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-                    "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-                    "requires": {
-                        "@opentelemetry/api": "^1.0.1",
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                },
                 "tslib": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -12479,11 +12251,11 @@
             }
         },
         "@azure/core-tracing": {
-            "version": "1.0.0-preview.12",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
-            "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
+            "version": "1.0.0-preview.13",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+            "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
             "requires": {
-                "@opentelemetry/api": "^1.0.0",
+                "@opentelemetry/api": "^1.0.1",
                 "tslib": "^2.2.0"
             },
             "dependencies": {
@@ -12518,23 +12290,13 @@
                 "uuid": "^8.3.0"
             },
             "dependencies": {
-                "jwa": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-                    "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+                "@azure/core-tracing": {
+                    "version": "1.0.0-preview.12",
+                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
+                    "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
                     "requires": {
-                        "buffer-equal-constant-time": "1.0.1",
-                        "ecdsa-sig-formatter": "1.0.11",
-                        "safe-buffer": "^5.0.1"
-                    }
-                },
-                "jws": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-                    "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-                    "requires": {
-                        "jwa": "^2.0.0",
-                        "safe-buffer": "^5.0.1"
+                        "@opentelemetry/api": "^1.0.0",
+                        "tslib": "^2.2.0"
                     }
                 },
                 "open": {
@@ -12553,7 +12315,6 @@
                 }
             }
         },
-<<<<<<< HEAD
         "@azure/loganalytics": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
@@ -12563,8 +12324,6 @@
                 "tslib": "^1.9.3"
             }
         },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
         "@azure/logger": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -12609,6 +12368,18 @@
                 "tunnel": "0.0.6",
                 "uuid": "^8.3.2",
                 "xml2js": "^0.4.19"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                }
             }
         },
         "@azure/ms-rest-nodeauth": {
@@ -12657,12 +12428,12 @@
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -12774,9 +12545,9 @@
             }
         },
         "@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
         "@microsoft/eslint-config-azuretools": {
@@ -12853,9 +12624,9 @@
             "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
         },
         "@types/eslint": {
-            "version": "7.28.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-            "integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+            "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -12900,9 +12671,9 @@
             "dev": true
         },
         "@types/glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
             "dev": true,
             "requires": {
                 "@types/minimatch": "*",
@@ -12955,14 +12726,14 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.17.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.21.tgz",
-            "integrity": "sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA=="
+            "version": "14.17.33",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
         },
         "@types/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
             "dev": true
         },
         "@types/source-list-map": {
@@ -13039,9 +12810,9 @@
             "dev": true
         },
         "@types/webpack": {
-            "version": "4.41.31",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.31.tgz",
-            "integrity": "sha512-/i0J7sepXFIp1ZT7FjUGi1eXMCg8HCCzLJEQkKsOtbJFontsJLolBcDC+3qxn5pPwiCt1G0ZdRmYRzNBtvpuGQ==",
+            "version": "4.41.32",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
+            "integrity": "sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -13099,6 +12870,17 @@
                 "@typescript-eslint/typescript-estree": "4.33.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "eslint-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/parser": {
@@ -13384,6 +13166,27 @@
                 "xpath.js": "~1.1.0"
             },
             "dependencies": {
+                "jwa": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+                    "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-equal-constant-time": "1.0.1",
+                        "ecdsa-sig-formatter": "1.0.11",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "jws": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+                    "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+                    "dev": true,
+                    "requires": {
+                        "jwa": "^1.4.1",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -13488,7 +13291,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "optional": true
+            "devOptional": true
         },
         "archy": {
             "version": "1.0.0",
@@ -13500,7 +13303,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
             "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -13787,12 +13590,12 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "optional": true
+            "devOptional": true
         },
         "big-integer": {
-            "version": "1.6.49",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
-            "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
             "dev": true
         },
         "big.js": {
@@ -13831,7 +13634,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -13842,7 +13645,7 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "optional": true,
+                    "devOptional": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -13889,23 +13692,23 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
-            "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+            "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001264",
-                "electron-to-chromium": "^1.3.857",
+                "caniuse-lite": "^1.0.30001280",
+                "electron-to-chromium": "^1.3.896",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.77",
-                "picocolors": "^0.2.1"
+                "node-releases": "^2.0.1",
+                "picocolors": "^1.0.0"
             }
         },
         "buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -13972,6 +13775,12 @@
                 "unique-filename": "^1.1.1"
             },
             "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
+                },
                 "mkdirp": {
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -14019,9 +13828,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001265",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+            "version": "1.0.30001280",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
+            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
             "dev": true
         },
         "chainsaw": {
@@ -14102,10 +13911,10 @@
             }
         },
         "chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "devOptional": true
         },
         "chrome-trace-event": {
             "version": "1.0.3",
@@ -14219,26 +14028,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
@@ -14410,7 +14199,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "optional": true
+            "devOptional": true
         },
         "convert-source-map": {
             "version": "1.8.0",
@@ -14419,6 +14208,14 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
             }
         },
         "copy-descriptor": {
@@ -14504,9 +14301,9 @@
             }
         },
         "css-what": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
             "dev": true
         },
         "d": {
@@ -14554,7 +14351,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
             "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "mimic-response": "^2.0.0"
             }
@@ -14563,7 +14360,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "optional": true
+            "devOptional": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -14661,12 +14458,6 @@
                     "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
                     "dev": true
                 },
-                "pify": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-                    "dev": true
-                },
                 "rimraf": {
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -14687,7 +14478,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "optional": true
+            "devOptional": true
         },
         "denodeify": {
             "version": "1.2.1",
@@ -14705,7 +14496,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "optional": true
+            "devOptional": true
         },
         "diff": {
             "version": "5.0.0",
@@ -14819,9 +14610,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.862",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.862.tgz",
-            "integrity": "sha512-o+FMbCD+hAUJ9S8bfz/FaqA0gE8OpCCm58KhhGogOEqiA1BLFSoVYLi+tW+S/ZavnqBn++n0XZm7HQiBVPs8Jg==",
+            "version": "1.3.897",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.897.tgz",
+            "integrity": "sha512-nRNZhAZ7hVCe75jrCUG7xLOqHMwloJMj6GEXEzY4OMahRGgwerAo+ls/qbqUwFH+E20eaSncKkQ4W8KP5SOiAg==",
             "dev": true
         },
         "emoji-regex": {
@@ -15044,23 +14835,6 @@
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "eslint-utils": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-                    "dev": true,
-                    "requires": {
-                        "eslint-visitor-keys": "^1.1.0"
-                    },
-                    "dependencies": {
-                        "eslint-visitor-keys": {
-                            "version": "1.3.0",
-                            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                            "dev": true
-                        }
-                    }
-                },
                 "ignore": {
                     "version": "4.0.6",
                     "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -15091,12 +14865,13 @@
             }
         },
         "eslint-module-utils": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
-            "integrity": "sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
+            "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
             "dev": true,
             "requires": {
                 "debug": "^3.2.7",
+                "find-up": "^2.1.0",
                 "pkg-dir": "^2.0.0"
             },
             "dependencies": {
@@ -15112,24 +14887,22 @@
             }
         },
         "eslint-plugin-import": {
-            "version": "2.24.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
-            "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
+            "version": "2.25.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
+            "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flat": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flat": "^1.2.5",
                 "debug": "^2.6.9",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.6",
-                "eslint-module-utils": "^2.6.2",
-                "find-up": "^2.0.0",
+                "eslint-module-utils": "^2.7.1",
                 "has": "^1.0.3",
-                "is-core-module": "^2.6.0",
+                "is-core-module": "^2.8.0",
+                "is-glob": "^4.0.3",
                 "minimatch": "^3.0.4",
-                "object.values": "^1.1.4",
-                "pkg-up": "^2.0.0",
-                "read-pkg-up": "^3.0.0",
+                "object.values": "^1.1.5",
                 "resolve": "^1.20.0",
                 "tsconfig-paths": "^3.11.0"
             },
@@ -15171,12 +14944,20 @@
             }
         },
         "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^2.0.0"
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "eslint-visitor-keys": {
@@ -15220,9 +15001,9 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
                 }
             }
@@ -15237,9 +15018,9 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
                 }
             }
@@ -15394,7 +15175,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "optional": true
+            "devOptional": true
         },
         "expand-tilde": {
             "version": "2.0.2",
@@ -15828,9 +15609,9 @@
             }
         },
         "flatted": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+            "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
             "dev": true
         },
         "flush-write-stream": {
@@ -15844,9 +15625,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
         },
         "for-in": {
             "version": "1.0.2",
@@ -15864,12 +15645,12 @@
             }
         },
         "form-data": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             }
         },
@@ -15886,7 +15667,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "optional": true
+            "devOptional": true
         },
         "fs-extra": {
             "version": "8.1.0",
@@ -15969,7 +15750,7 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -15985,33 +15766,13 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
+                    "devOptional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "optional": true,
+                    "devOptional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -16060,7 +15821,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "optional": true
+            "devOptional": true
         },
         "glob": {
             "version": "7.2.0",
@@ -16397,9 +16158,9 @@
             }
         },
         "globals": {
-            "version": "13.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-            "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+            "version": "13.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+            "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -16536,7 +16297,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "optional": true
+            "devOptional": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -16605,10 +16366,13 @@
             }
         },
         "hosted-git-info": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+            "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "html-to-text": {
             "version": "5.1.1",
@@ -16732,21 +16496,21 @@
             "dev": true
         },
         "husky": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-            "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true
         },
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "optional": true
+            "devOptional": true
         },
         "ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true
         },
         "import-fresh": {
@@ -16970,9 +16734,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-            "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -17055,10 +16819,13 @@
             "dev": true
         },
         "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "devOptional": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
         },
         "is-glob": {
             "version": "4.0.3",
@@ -17244,9 +17011,9 @@
             "dev": true
         },
         "jest-worker": {
-            "version": "27.2.5",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
-            "integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
+            "version": "27.3.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
+            "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -17334,6 +17101,25 @@
                 "semver": "^5.6.0"
             },
             "dependencies": {
+                "jwa": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+                    "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+                    "requires": {
+                        "buffer-equal-constant-time": "1.0.1",
+                        "ecdsa-sig-formatter": "1.0.11",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "jws": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+                    "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+                    "requires": {
+                        "jwa": "^1.4.1",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -17348,9 +17134,9 @@
             "dev": true
         },
         "jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -17358,11 +17144,11 @@
             }
         },
         "jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
             "requires": {
-                "jwa": "^1.4.1",
+                "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -17370,7 +17156,7 @@
             "version": "7.7.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
             "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "node-addon-api": "^3.0.0",
                 "prebuild-install": "^6.0.0"
@@ -17393,9 +17179,9 @@
             }
         },
         "lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+            "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
             "dev": true,
             "requires": {
                 "readable-stream": "^2.0.5"
@@ -17478,15 +17264,33 @@
             "dev": true
         },
         "load-json-file": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "^0.2.0"
+                    }
+                }
             }
         },
         "loader-runner": {
@@ -17496,9 +17300,9 @@
             "dev": true
         },
         "loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
@@ -17531,12 +17335,6 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
         },
         "lodash.includes": {
             "version": "4.3.0",
@@ -17884,16 +17682,16 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.50.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-            "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
         },
         "mime-types": {
-            "version": "2.1.33",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-            "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+            "version": "2.1.34",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
             "requires": {
-                "mime-db": "1.50.0"
+                "mime-db": "1.51.0"
             }
         },
         "mimic-fn": {
@@ -17906,7 +17704,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
             "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "optional": true
+            "devOptional": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -17991,7 +17789,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "optional": true
+            "devOptional": true
         },
         "mocha": {
             "version": "8.4.0",
@@ -18106,6 +17904,12 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
                 "js-yaml": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
@@ -18161,6 +17965,17 @@
                     "dev": true,
                     "requires": {
                         "picomatch": "^2.2.1"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
                     }
                 },
                 "supports-color": {
@@ -18252,9 +18067,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "msal": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.14.tgz",
-            "integrity": "sha512-k8M5+/jbfSQoCf7CyQzBP5HE5mY8TkBujykLGTEp2x0MvOK/FQsfUTNis28zlvvPVzhgrhb5GQiGM8rRpXyHdA==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.15.tgz",
+            "integrity": "sha512-H/CxkeZJ4laEK6GZ/cDKQoYjBTvDNFK3hDC8mfU8IkuZvKFfFdo9KM89r8spXY7xnBK9SQBAjIuQgwUogeUw7g==",
             "requires": {
                 "tslib": "^1.9.3"
             }
@@ -18315,7 +18130,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
             "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "optional": true
+            "devOptional": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -18339,7 +18154,7 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
             "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "semver": "^5.4.1"
             },
@@ -18348,7 +18163,7 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "optional": true
+                    "devOptional": true
                 }
             }
         },
@@ -18356,20 +18171,20 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-            "optional": true
+            "devOptional": true
         },
         "node-fetch": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-            "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
         },
         "node-releases": {
-            "version": "1.1.77",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
-            "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+            "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
             "dev": true
         },
         "normalize-package-data": {
@@ -18384,6 +18199,12 @@
                 "validate-npm-package-license": "^3.0.1"
             },
             "dependencies": {
+                "hosted-git-info": {
+                    "version": "2.8.9",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+                    "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+                    "dev": true
+                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -18420,7 +18241,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -18620,9 +18441,9 @@
             }
         },
         "open": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.3.0.tgz",
-            "integrity": "sha512-7INcPWb1UcOwSQxAXTnBJ+FxVV4MPs/X++FWWBtgY69/J5lc+tCteMt/oFK1MnkyHC4VILLa9ntmwKTwDR4Q9w==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
             "requires": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -18737,13 +18558,12 @@
             }
         },
         "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-node-version": {
@@ -18860,9 +18680,9 @@
             "dev": true
         },
         "picocolors": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "picomatch": {
@@ -18872,9 +18692,9 @@
             "dev": true
         },
         "pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
         },
         "pinkie": {
@@ -18901,15 +18721,6 @@
                 "find-up": "^2.1.0"
             }
         },
-        "pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-            "dev": true,
-            "requires": {
-                "find-up": "^2.1.0"
-            }
-        },
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -18920,7 +18731,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
             "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -18935,18 +18746,6 @@
                 "simple-get": "^3.0.3",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
-            },
-            "dependencies": {
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-                    "optional": true,
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                }
             }
         },
         "prelude-ls": {
@@ -18991,10 +18790,10 @@
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "devOptional": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -19009,6 +18808,18 @@
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
                 "pump": "^2.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "punycode": {
@@ -19043,7 +18854,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -19055,7 +18866,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "optional": true
+                    "devOptional": true
                 }
             }
         },
@@ -19069,35 +18880,64 @@
             }
         },
         "read-pkg": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^4.0.0",
+                "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "path-type": "^1.0.0"
             },
             "dependencies": {
                 "path-type": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
         "read-pkg-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -19113,6 +18953,14 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "devOptional": true
+                }
             }
         },
         "readdirp": {
@@ -19312,9 +19160,9 @@
             }
         },
         "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -19469,13 +19317,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "optional": true
+            "devOptional": true
         },
         "simple-get": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
             "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -19497,6 +19345,14 @@
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
                 "is-fullwidth-code-point": "^3.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                }
             }
         },
         "snapdragon": {
@@ -19729,9 +19585,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-            "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
             "dev": true
         },
         "split-string": {
@@ -19859,17 +19715,41 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
                 "safe-buffer": "~5.1.0"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
             }
         },
         "string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "devOptional": true,
             "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "devOptional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "devOptional": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
             }
         },
         "string.prototype.trimend": {
@@ -19939,13 +19819,12 @@
             }
         },
         "table": {
-            "version": "6.7.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-            "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+            "version": "6.7.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
+            "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
-                "lodash.clonedeep": "^4.5.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.3",
@@ -19953,9 +19832,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-                    "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+                    "version": "8.8.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.0.tgz",
+                    "integrity": "sha512-L+cJ/+pkdICMueKR6wIx3VP2fjIx3yAhuvadUv/osv9yFD7OVZy442xFF+Oeu3ZvmhBGQzoF6mTSt+LUWBmGQg==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -19964,11 +19843,28 @@
                         "uri-js": "^4.2.2"
                     }
                 },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                     "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
                 }
             }
         },
@@ -19992,6 +19888,12 @@
                 "yallist": "^4.0.0"
             },
             "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
+                },
                 "mkdirp": {
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -20004,37 +19906,19 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
                 "tar-stream": "^2.1.4"
-            },
-            "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-                    "optional": true
-                },
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-                    "optional": true,
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                }
             }
         },
         "tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -20047,7 +19931,7 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "optional": true,
+                    "devOptional": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -20057,60 +19941,49 @@
             }
         },
         "tas-client": {
-            "version": "0.1.21",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.21.tgz",
-            "integrity": "sha512-7UuIwOXarCYoCTrQHY5n7M+63XuwMC0sVUdbPQzxqDB9wMjIW0JF39dnp3yoJnxr4jJUVhPtvkkXZbAD0BxCcA==",
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.26.tgz",
+            "integrity": "sha512-o9wYpOwf1jhIose0ArEeW/Zr2T/XZnCKDrNXsCiZ/ctpg0DliU76tJ1rbBGlrOvjzLrMY1S3QwZWOAaF7+5HDw==",
             "requires": {
-                "axios": "^0.21.1"
-            }
-        },
-        "terser": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-            "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
-            "dev": true,
-            "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.7.2",
-                "source-map-support": "~0.5.20"
+                "axios": "^0.22.0"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-                    "dev": true
+                "axios": {
+                    "version": "0.22.0",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
+                    "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+                    "requires": {
+                        "follow-redirects": "^1.14.4"
+                    }
                 }
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
-            "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
+            "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
             "dev": true,
             "requires": {
                 "jest-worker": "^27.0.6",
-                "p-limit": "^3.1.0",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^5.7.2"
             },
             "dependencies": {
-                "p-limit": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                "acorn": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
                     "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
+                    "optional": true,
+                    "peer": true
+                },
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
                 },
                 "serialize-javascript": {
                     "version": "6.0.0",
@@ -20119,6 +19992,25 @@
                     "dev": true,
                     "requires": {
                         "randombytes": "^2.1.0"
+                    }
+                },
+                "terser": {
+                    "version": "5.10.0",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+                    "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "^2.20.0",
+                        "source-map": "~0.7.2",
+                        "source-map-support": "~0.5.20"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.7.3",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                            "dev": true
+                        }
                     }
                 }
             }
@@ -20507,7 +20399,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -20551,9 +20443,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
             "dev": true
         },
         "uc.micro": {
@@ -20870,9 +20762,9 @@
             }
         },
         "vsce": {
-            "version": "1.100.1",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.1.tgz",
-            "integrity": "sha512-1VjLyse5g6e2eQ6jUpslu7IDq44velwF8Jy8s7ePdwGNuG8EzfmaOfVyig3ZSMJ0l8DiJmZllx5bRAB4RMdnHg==",
+            "version": "1.103.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.103.1.tgz",
+            "integrity": "sha512-98oKQKKRp7J/vTIk1cuzom5cezZpYpRHs3WlySdsrTCrAEipB/HvaPTc4VZ3hGZHzHXS9P5p2L0IllntJeXwiQ==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^11.0.1",
@@ -20882,6 +20774,7 @@
                 "denodeify": "^1.2.1",
                 "glob": "^7.0.6",
                 "hosted-git-info": "^4.0.2",
+                "keytar": "^7.7.0",
                 "leven": "^3.1.0",
                 "lodash": "^4.17.15",
                 "markdown-it": "^10.0.0",
@@ -20945,15 +20838,6 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
-                },
-                "hosted-git-info": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-                    "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
                 },
                 "semver": {
                     "version": "5.7.1",
@@ -21214,7 +21098,6 @@
             }
         },
         "vscode-azureextensionui": {
-<<<<<<< HEAD
             "version": "0.48.5",
             "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.5.tgz",
             "integrity": "sha512-we0PKr2jggI2OJtua/A//Kck3Z3SCbCmg5TVKBAF8RWL5oLFLoK9b2HWoNWMUau62gbrdOa5U1CRaMJol4VlQA==",
@@ -21226,643 +21109,451 @@
                 "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
-=======
-            "version": "file:..\\vscode-azuretools\\ui\\vscode-azureextensionui-0.49.0.tgz",
-                "integrity": "sha512-pyCMLBBGu4j5NJmqqHhkQjWk7MGJ2Os4T/TL0ITLQSO4MjQSyewwN7HampsdlM3LR1+gGKyYhV10ZbNv2UUJNg==",
-                "requires": {
-                    "@azure/arm-resources": "^4.0.0",
-                    "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                    "@azure/arm-resources-subscriptions": "^1.0.0",
-                    "@azure/arm-storage": "^15.0.0",
-                    "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                    "@azure/ms-rest-azure-env": "^2.0.0",
-                    "@azure/ms-rest-js": "^2.6.0",
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
                 "dayjs": "^1.9.3",
-                    "escape-string-regexp": "^2.0.0",
-                    "html-to-text": "^5.1.1",
-                    "open": "^8.0.4",
-                    "semver": "^5.7.1",
-                    "uuid": "^8.3.2",
-                    "vscode-extension-telemetry": "^0.3.1",
-                    "vscode-nls": "^4.1.1",
-                    "vscode-tas-client": "^0.1.22"
-                },
-                "dependencies": {
-<<<<<<< HEAD
+                "escape-string-regexp": "^2.0.0",
+                "html-to-text": "^5.1.1",
+                "open": "^8.0.4",
+                "semver": "^5.7.1",
+                "uuid": "^8.3.2",
+                "vscode-extension-telemetry": "^0.3.1",
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.22"
+            },
+            "dependencies": {
                 "@azure/arm-resources": {
-                        "version": "3.0.0",
-                        "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-                        "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
-                        "requires": {
-                            "@azure/ms-rest-azure-js": "^2.0.1",
-                            "@azure/ms-rest-js": "^2.0.4",
-                            "tslib": "^1.10.0"
-                        }
-                    },
-=======
->>>>>>> 14c2b852407862c4c077329e9704ea1250b0e8cc
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
+                    "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+                    "requires": {
+                        "@azure/ms-rest-azure-js": "^2.0.1",
+                        "@azure/ms-rest-js": "^2.0.4",
+                        "tslib": "^1.10.0"
+                    }
+                },
                 "escape-string-regexp": {
-                        "version": "2.0.0",
-                        "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                        "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                    },
-                    "semver": {
-                        "version": "5.7.1",
-                        "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                        "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                    }
-                }
-            },
-            "vscode-extension-telemetry": {
-                "version": "0.3.2",
-                "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-                "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw=="
-            },
-            "vscode-nls": {
-                "version": "4.1.2",
-                "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-                "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
-            },
-            "vscode-tas-client": {
-                "version": "0.1.22",
-                "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.22.tgz",
-                "integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
-                "requires": {
-                    "tas-client": "0.1.21"
-                }
-            },
-            "vscode-test": {
-                "version": "1.6.1",
-                "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-                "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-                "dev": true,
-                "requires": {
-                    "http-proxy-agent": "^4.0.1",
-                    "https-proxy-agent": "^5.0.0",
-                    "rimraf": "^3.0.2",
-                    "unzipper": "^0.10.11"
-                }
-            },
-            "watchpack": {
-                "version": "2.2.0",
-                "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-                "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
-                "dev": true,
-                "requires": {
-                    "glob-to-regexp": "^0.4.1",
-                    "graceful-fs": "^4.1.2"
-                }
-            },
-            "webidl-conversions": {
-                "version": "3.0.1",
-                "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-            },
-            "webpack": {
-                "version": "5.58.1",
-                "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.1.tgz",
-                "integrity": "sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==",
-                "dev": true,
-                "requires": {
-                    "@types/eslint-scope": "^3.7.0",
-                    "@types/estree": "^0.0.50",
-                    "@webassemblyjs/ast": "1.11.1",
-                    "@webassemblyjs/wasm-edit": "1.11.1",
-                    "@webassemblyjs/wasm-parser": "1.11.1",
-                    "acorn": "^8.4.1",
-                    "acorn-import-assertions": "^1.7.6",
-                    "browserslist": "^4.14.5",
-                    "chrome-trace-event": "^1.0.2",
-                    "enhanced-resolve": "^5.8.3",
-                    "es-module-lexer": "^0.9.0",
-                    "eslint-scope": "5.1.1",
-                    "events": "^3.2.0",
-                    "glob-to-regexp": "^0.4.1",
-                    "graceful-fs": "^4.2.4",
-                    "json-parse-better-errors": "^1.0.2",
-                    "loader-runner": "^4.2.0",
-                    "mime-types": "^2.1.27",
-                    "neo-async": "^2.6.2",
-                    "schema-utils": "^3.1.0",
-                    "tapable": "^2.1.1",
-                    "terser-webpack-plugin": "^5.1.3",
-                    "watchpack": "^2.2.0",
-                    "webpack-sources": "^3.2.0"
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
                 },
-                "dependencies": {
-                    "acorn": {
-                        "version": "8.5.0",
-                        "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-                        "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-                        "dev": true
-                    },
-                    "acorn-import-assertions": {
-                        "version": "1.8.0",
-                        "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-                        "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-                        "dev": true,
-                        "requires": {}
-                    },
-                    "enhanced-resolve": {
-                        "version": "5.8.3",
-                        "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-                        "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
-                        "dev": true,
-                        "requires": {
-                            "graceful-fs": "^4.2.4",
-                            "tapable": "^2.2.0"
-                        }
-                    },
-                    "tapable": {
-                        "version": "2.2.1",
-                        "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-                        "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-                        "dev": true
-                    },
-                    "webpack-sources": {
-                        "version": "3.2.1",
-                        "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-                        "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
-                        "dev": true
-                    }
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                 }
-            },
-            "webpack-cli": {
-                "version": "4.9.0",
-                "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
-                "integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
-                "dev": true,
-                "requires": {
-                    "@discoveryjs/json-ext": "^0.5.0",
-                    "@webpack-cli/configtest": "^1.1.0",
-                    "@webpack-cli/info": "^1.4.0",
-                    "@webpack-cli/serve": "^1.6.0",
-                    "colorette": "^2.0.14",
-                    "commander": "^7.0.0",
-                    "execa": "^5.0.0",
-                    "fastest-levenshtein": "^1.0.12",
-                    "import-local": "^3.0.2",
-                    "interpret": "^2.2.0",
-                    "rechoir": "^0.7.0",
-                    "v8-compile-cache": "^2.2.0",
-                    "webpack-merge": "^5.7.3"
-                },
-                "dependencies": {
-                    "commander": {
-                        "version": "7.2.0",
-                        "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-                        "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-                        "dev": true
-                    },
-                    "interpret": {
-                        "version": "2.2.0",
-                        "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-                        "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
-                        "dev": true
-                    },
-                    "rechoir": {
-                        "version": "0.7.1",
-                        "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-                        "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
-                        "dev": true,
-                        "requires": {
-                            "resolve": "^1.9.0"
-                        }
-                    }
-                }
-            },
-            "webpack-merge": {
-                "version": "5.8.0",
-                "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-                "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
-                "dev": true,
-                "requires": {
-                    "clone-deep": "^4.0.1",
-                    "wildcard": "^2.0.0"
-                }
-            },
-            "webpack-sources": {
-                "version": "1.4.3",
-                "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-                "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-                "dev": true,
-                "requires": {
-                    "source-list-map": "^2.0.0",
-                    "source-map": "~0.6.1"
-                }
-            },
-            "whatwg-url": {
-                "version": "5.0.0",
-                "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-                "requires": {
-                    "tr46": "~0.0.3",
-                    "webidl-conversions": "^3.0.0"
-                }
-            },
-            "which": {
-                "version": "2.0.2",
-                "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                "dev": true,
-                "requires": {
-                    "isexe": "^2.0.0"
-                }
-            },
-            "which-boxed-primitive": {
-                "version": "1.0.2",
-                "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-                "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-                "dev": true,
-                "requires": {
-                    "is-bigint": "^1.0.1",
-                    "is-boolean-object": "^1.1.0",
-                    "is-number-object": "^1.0.4",
-                    "is-string": "^1.0.5",
-                    "is-symbol": "^1.0.3"
-                }
-            },
-            "which-module": {
-                "version": "1.0.0",
-                "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-                "dev": true
-            },
-            "wide-align": {
-                "version": "1.1.3",
-                "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-                "devOptional": true,
-                "requires": {
-                    "string-width": "^1.0.2 || 2"
-                },
-                "dependencies": {
-                    "ansi-regex": {
-                        "version": "3.0.0",
-                        "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                        "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                        "devOptional": true
-                    },
-                    "is-fullwidth-code-point": {
-                        "version": "2.0.0",
-                        "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                        "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                        "devOptional": true
-                    },
-                    "string-width": {
-                        "version": "2.1.1",
-                        "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                        "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                        "devOptional": true,
-                        "requires": {
-                            "is-fullwidth-code-point": "^2.0.0",
-                            "strip-ansi": "^4.0.0"
-                        }
-                    },
-                    "strip-ansi": {
-                        "version": "4.0.0",
-                        "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                        "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                        "devOptional": true,
-                        "requires": {
-                            "ansi-regex": "^3.0.0"
-                        }
-                    }
-                }
-            },
-            "wildcard": {
-                "version": "2.0.0",
-                "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-                "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-                "dev": true
-            },
-            "word-wrap": {
-                "version": "1.2.3",
-                "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-                "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-                "dev": true
-            },
-            "workerpool": {
-                "version": "6.1.0",
-                "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-                "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
-                "dev": true
-            },
-            "wrap-ansi": {
-                "version": "2.1.0",
-                "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                "dev": true,
-                "requires": {
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1"
-                },
-                "dependencies": {
-                    "ansi-regex": {
-                        "version": "2.1.1",
-                        "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                        "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                        "dev": true
-                    },
-                    "is-fullwidth-code-point": {
-                        "version": "1.0.0",
-                        "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                        "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                        "dev": true,
-                        "requires": {
-                            "number-is-nan": "^1.0.0"
-                        }
-                    },
-                    "string-width": {
-                        "version": "1.0.2",
-                        "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                        "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                        "dev": true,
-                        "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                        }
-                    },
-                    "strip-ansi": {
-                        "version": "3.0.1",
-                        "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                        "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                        "dev": true,
-                        "requires": {
-                            "ansi-regex": "^2.0.0"
-                        }
-                    }
-                }
-            },
-            "wrappy": {
-                "version": "1.0.2",
-                "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                "devOptional": true
-            },
-            "xml": {
-                "version": "1.0.1",
-                "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-                "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-                "dev": true
-            },
-            "xml2js": {
-                "version": "0.4.23",
-                "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-                "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-                "requires": {
-                    "sax": ">=0.6.0",
-                    "xmlbuilder": "~11.0.0"
-                }
-            },
-            "xmlbuilder": {
-                "version": "11.0.1",
-                "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-                "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-            },
-            "xpath.js": {
-                "version": "1.1.0",
-                "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-                "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-                "dev": true
-            },
-            "xtend": {
-                "version": "4.0.2",
-                "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-                "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-                "dev": true
-            },
-            "y18n": {
-                "version": "3.2.2",
-                "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-                "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-                "dev": true
-            },
-            "yallist": {
-                "version": "4.0.0",
-                "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-            },
-            "yargs": {
-                "version": "7.1.2",
-                "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
-                "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
-                "dev": true,
-                "requires": {
-                    "camelcase": "^3.0.0",
-                    "cliui": "^3.2.0",
-                    "decamelize": "^1.1.1",
-                    "get-caller-file": "^1.0.1",
-                    "os-locale": "^1.4.0",
-                    "read-pkg-up": "^1.0.1",
-                    "require-directory": "^2.1.1",
-                    "require-main-filename": "^1.0.1",
-                    "set-blocking": "^2.0.0",
-                    "string-width": "^1.0.2",
-                    "which-module": "^1.0.0",
-                    "y18n": "^3.2.1",
-                    "yargs-parser": "^5.0.1"
-                },
-                "dependencies": {
-                    "ansi-regex": {
-                        "version": "2.1.1",
-                        "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                        "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                        "dev": true
-                    },
-                    "find-up": {
-                        "version": "1.1.2",
-                        "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                        "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                        "dev": true,
-                        "requires": {
-                            "path-exists": "^2.0.0",
-                            "pinkie-promise": "^2.0.0"
-                        }
-                    },
-                    "is-fullwidth-code-point": {
-                        "version": "1.0.0",
-                        "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                        "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                        "dev": true,
-                        "requires": {
-                            "number-is-nan": "^1.0.0"
-                        }
-                    },
-                    "load-json-file": {
-                        "version": "1.1.0",
-                        "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                        "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                        "dev": true,
-                        "requires": {
-                            "graceful-fs": "^4.1.2",
-                            "parse-json": "^2.2.0",
-                            "pify": "^2.0.0",
-                            "pinkie-promise": "^2.0.0",
-                            "strip-bom": "^2.0.0"
-                        }
-                    },
-                    "parse-json": {
-                        "version": "2.2.0",
-                        "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                        "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                        "dev": true,
-                        "requires": {
-                            "error-ex": "^1.2.0"
-                        }
-                    },
-                    "path-exists": {
-                        "version": "2.1.0",
-                        "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                        "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                        "dev": true,
-                        "requires": {
-                            "pinkie-promise": "^2.0.0"
-                        }
-                    },
-                    "path-type": {
-                        "version": "1.1.0",
-                        "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                        "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                        "dev": true,
-                        "requires": {
-                            "graceful-fs": "^4.1.2",
-                            "pify": "^2.0.0",
-                            "pinkie-promise": "^2.0.0"
-                        }
-                    },
-                    "pify": {
-                        "version": "2.3.0",
-                        "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                        "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                        "dev": true
-                    },
-                    "read-pkg": {
-                        "version": "1.1.0",
-                        "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                        "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                        "dev": true,
-                        "requires": {
-                            "load-json-file": "^1.0.0",
-                            "normalize-package-data": "^2.3.2",
-                            "path-type": "^1.0.0"
-                        }
-                    },
-                    "read-pkg-up": {
-                        "version": "1.0.1",
-                        "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                        "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                        "dev": true,
-                        "requires": {
-                            "find-up": "^1.0.0",
-                            "read-pkg": "^1.0.0"
-                        }
-                    },
-                    "string-width": {
-                        "version": "1.0.2",
-                        "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                        "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                        "dev": true,
-                        "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                        }
-                    },
-                    "strip-ansi": {
-                        "version": "3.0.1",
-                        "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                        "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                        "dev": true,
-                        "requires": {
-                            "ansi-regex": "^2.0.0"
-                        }
-                    },
-                    "strip-bom": {
-                        "version": "2.0.0",
-                        "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                        "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                        "dev": true,
-                        "requires": {
-                            "is-utf8": "^0.2.0"
-                        }
-                    },
-                    "yargs-parser": {
-                        "version": "5.0.1",
-                        "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
-                        "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
-                        "dev": true,
-                        "requires": {
-                            "camelcase": "^3.0.0",
-                            "object.assign": "^4.1.0"
-                        }
-                    }
-                }
-            },
-            "yargs-parser": {
-                "version": "20.2.4",
-                "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-                "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-                "dev": true
-            },
-            "yargs-unparser": {
-                "version": "2.0.0",
-                "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-                "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-                "dev": true,
-                "requires": {
-                    "camelcase": "^6.0.0",
-                    "decamelize": "^4.0.0",
-                    "flat": "^5.0.2",
-                    "is-plain-obj": "^2.1.0"
-                },
-                "dependencies": {
-                    "camelcase": {
-                        "version": "6.2.0",
-                        "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-                        "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-                        "dev": true
-                    },
-                    "decamelize": {
-                        "version": "4.0.0",
-                        "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-                        "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-                        "dev": true
-                    }
-                }
-            },
-            "yauzl": {
-                "version": "2.10.0",
-                "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-                "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-                "dev": true,
-                "requires": {
-                    "buffer-crc32": "~0.2.3",
-                    "fd-slicer": "~1.1.0"
-                }
-            },
-            "yazl": {
-                "version": "2.5.1",
-                "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-                "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-                "dev": true,
-                "requires": {
-                    "buffer-crc32": "~0.2.3"
-                }
-            },
-            "yn": {
-                "version": "2.0.0",
-                "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-                "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-                "dev": true
-            },
-            "yocto-queue": {
-                "version": "0.1.0",
-                "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-                "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-                "dev": true
             }
+        },
+        "vscode-extension-telemetry": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
+            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw=="
+        },
+        "vscode-nls": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+            "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+        },
+        "vscode-tas-client": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.27.tgz",
+            "integrity": "sha512-wyYSdbaSoInXmaXVO54ihvmG6uoRIQ4TdVctJgYqf66oTvUq6e5F3XgtiYRSM6yaqhI0rPqPrYIzLNOO524Z9A==",
+            "requires": {
+                "tas-client": "0.1.26"
+            }
+        },
+        "vscode-test": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
+        },
+        "watchpack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "dev": true,
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "webpack": {
+            "version": "5.64.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.1.tgz",
+            "integrity": "sha512-b4FHmRgaaAjP+aVOVz41a9Qa5SmkUPQ+u8FntTQ1roPHahSComB6rXnLwc976VhUY4CqTaLu5mCswuHiNhOfVw==",
+            "dev": true,
+            "requires": {
+                "@types/eslint-scope": "^3.7.0",
+                "@types/estree": "^0.0.50",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.4.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.8.3",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.4",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.2.0",
+                "webpack-sources": "^3.2.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+                    "dev": true
+                },
+                "acorn-import-assertions": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+                    "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "enhanced-resolve": {
+                    "version": "5.8.3",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+                    "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.4",
+                        "tapable": "^2.2.0"
+                    }
+                },
+                "tapable": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+                    "dev": true
+                },
+                "webpack-sources": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
+                    "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "dev": true,
+            "requires": {
+                "@discoveryjs/json-ext": "^0.5.0",
+                "@webpack-cli/configtest": "^1.1.0",
+                "@webpack-cli/info": "^1.4.0",
+                "@webpack-cli/serve": "^1.6.0",
+                "colorette": "^2.0.14",
+                "commander": "^7.0.0",
+                "execa": "^5.0.0",
+                "fastest-levenshtein": "^1.0.12",
+                "import-local": "^3.0.2",
+                "interpret": "^2.2.0",
+                "rechoir": "^0.7.0",
+                "webpack-merge": "^5.7.3"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+                    "dev": true
+                },
+                "interpret": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+                    "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+                    "dev": true
+                },
+                "rechoir": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+                    "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+                    "dev": true,
+                    "requires": {
+                        "resolve": "^1.9.0"
+                    }
+                }
+            }
+        },
+        "webpack-merge": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "wildcard": "^2.0.0"
+            }
+        },
+        "webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "dev": true,
+            "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            }
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "devOptional": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "wildcard": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+            "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+            "dev": true
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
+        "workerpool": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "devOptional": true
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            }
+        },
+        "xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        },
+        "xpath.js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+            "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yargs": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
+            "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.1"
+            },
+            "dependencies": {
+                "yargs-parser": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+                    "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "object.assign": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "20.2.4",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "dev": true
+        },
+        "yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+                    "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+                    "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
+        "yazl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3"
+            }
+        },
+        "yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+            "dev": true
+        },
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
         }
     }
+}


### PR DESCRIPTION
Beware there are merge conflicts in the current package-lock.json file that this PR overwrites. Probably should take a look at those before merging.

Fixes CVE-2022-0155