### PR TITLE
Delete KubeEnvironments + other things

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,11 @@
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
                 "@azure/container-registry": "^1.0.0-beta.5",
-                "@azure/identity": "^1.5.2",
                 "@azure/loganalytics": "^0.3.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "open": "^8.0.4",
                 "semver": "^7.3.5",
-                "vscode-azureextensionui": "0.48.5",
+                "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.50.0.tgz",
                 "vscode-nls": "^4.1.1"
             },
             "devDependencies": {
@@ -41,7 +40,6 @@
                 "mocha": "^8.3.2",
                 "mocha-junit-reporter": "^2.0.0",
                 "mocha-multi-reporters": "^1.1.7",
-                "node-loader": "^2.0.0",
                 "ts-node": "^7.0.1",
                 "typescript": "^4.3.5",
                 "vsce": "^1.87.1",
@@ -120,6 +118,11 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@azure/arm-operationalinsights/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
         "node_modules/@azure/arm-resources": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
@@ -142,14 +145,32 @@
                 "tslib": "^1.10.0"
             }
         },
-        "node_modules/@azure/arm-storage": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
-            "integrity": "sha512-djN2tmEzvC4lNEYrk3PAXkf5ZcebGDqPZSh/cYKOleumD4eop5EpMX8d5LcSO/9EcSfPpCzutRg0AleMaPQ9Mg==",
+        "node_modules/@azure/arm-resources-subscriptions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
             "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-storage": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.0.0.tgz",
+            "integrity": "sha512-WS9eT3/vDQ7a1z/8K5BkPhoAi0ilo94yCSws4KyWq6UIA3RaXBDpYYAlN0TOxad9rPeOnWXWcB9gLw3DmjZ4wg==",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid": {
@@ -163,10 +184,16 @@
                 "tslib": "^1.10.0"
             }
         },
+        "node_modules/@azure/arm-storage/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
         "node_modules/@azure/arm-subscriptions": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
             "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "dev": true,
             "dependencies": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -315,67 +342,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-        "node_modules/@azure/identity": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-1.5.2.tgz",
-            "integrity": "sha512-vqyeRbd2i0h9F4mqW5JbkP1xfabqKQ21l/81osKhpOQ2LtwaJW6nw4+0PsVYnxcbPHFCIZt6EWAk74a3OGYZJA==",
-            "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "1.0.0-preview.12",
-                "@azure/logger": "^1.0.0",
-                "@azure/msal-node": "1.0.0-beta.6",
-                "@types/stoppable": "^1.1.0",
-                "axios": "^0.21.1",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "msal": "^1.0.2",
-                "open": "^7.0.0",
-                "qs": "^6.7.0",
-                "stoppable": "^1.1.0",
-                "tslib": "^2.0.0",
-                "uuid": "^8.3.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "optionalDependencies": {
-                "keytar": "^7.3.0"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/@azure/core-tracing": {
-            "version": "1.0.0-preview.12",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
-            "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
         "node_modules/@azure/loganalytics": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
@@ -455,28 +421,6 @@
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
                 "adal-node": "^0.2.2"
-            }
-        },
-        "node_modules/@azure/msal-common": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-            "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
-            "dependencies": {
-                "debug": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@azure/msal-node": {
-            "version": "1.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.0.0-beta.6.tgz",
-            "integrity": "sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==",
-            "dependencies": {
-                "@azure/msal-common": "^4.0.0",
-                "axios": "^0.21.1",
-                "jsonwebtoken": "^8.5.1",
-                "uuid": "^8.3.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -854,7 +798,8 @@
         "node_modules/@types/node": {
             "version": "14.17.33",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
+            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+            "dev": true
         },
         "node_modules/@types/semver": {
             "version": "7.3.9",
@@ -867,14 +812,6 @@
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
             "dev": true
-        },
-        "node_modules/@types/stoppable": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
-            "integrity": "sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/tapable": {
             "version": "1.0.8",
@@ -1149,6 +1086,14 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "node_modules/@vscode/extension-telemetry": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.7.tgz",
+            "integrity": "sha512-tXjChgxFN6EAfa6LIy/PE3fIbIvj0BnELUmGAG+8tUpsLY3g2iACcVM/UJJXtsU6db29tMqCLITUX2Dd3N06GA==",
+            "engines": {
+                "vscode": "^1.60.0"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -1567,7 +1512,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/archy": {
             "version": "1.0.0",
@@ -1579,7 +1524,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
             "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -1873,6 +1818,7 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.14.0"
             }
@@ -1947,7 +1893,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2017,7 +1963,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -2028,7 +1974,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -2105,7 +2051,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2146,7 +2092,8 @@
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -2246,6 +2193,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
             "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
@@ -2387,7 +2335,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -2618,7 +2566,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2740,7 +2688,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
@@ -2824,7 +2772,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -2939,7 +2887,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
             "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "mimic-response": "^2.0.0"
             },
@@ -2951,7 +2899,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -3104,7 +3052,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/denodeify": {
             "version": "1.2.1",
@@ -3125,7 +3073,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
             },
@@ -3268,6 +3216,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -3297,7 +3246,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -3808,6 +3757,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -3967,7 +3917,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4501,7 +4451,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -4592,7 +4542,8 @@
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
@@ -4604,7 +4555,7 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -4620,7 +4571,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4629,7 +4580,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -4647,6 +4598,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
             "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
@@ -4697,7 +4649,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/glob": {
             "version": "7.2.0",
@@ -5240,6 +5192,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -5269,6 +5222,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5295,7 +5249,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/has-value": {
             "version": "1.0.0",
@@ -5562,7 +5516,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5665,7 +5619,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.3",
@@ -5927,7 +5881,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -6185,7 +6139,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6289,84 +6243,17 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^5.6.0"
-            },
-            "engines": {
-                "node": ">=4",
-                "npm": ">=1.4.28"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-            "dependencies": {
-                "jwa": "^1.4.1",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/just-debounce": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
             "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
             "dev": true
         },
-        "node_modules/jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "node_modules/keytar": {
             "version": "7.7.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
             "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "node-addon-api": "^3.0.0",
@@ -6592,46 +6479,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
@@ -7039,7 +6891,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
             "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -7154,7 +7006,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/mocha": {
             "version": "8.4.0",
@@ -7524,17 +7376,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "node_modules/msal": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.15.tgz",
-            "integrity": "sha512-H/CxkeZJ4laEK6GZ/cDKQoYjBTvDNFK3hDC8mfU8IkuZvKFfFdo9KM89r8spXY7xnBK9SQBAjIuQgwUogeUw7g==",
-            "dependencies": {
-                "tslib": "^1.9.3"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/mute-stdout": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
@@ -7604,7 +7445,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
             "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -7628,7 +7469,7 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
             "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "semver": "^5.4.1"
             }
@@ -7637,7 +7478,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -7646,7 +7487,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/node-fetch": {
             "version": "2.6.6",
@@ -7657,25 +7498,6 @@
             },
             "engines": {
                 "node": "4.x || >=6.0.0"
-            }
-        },
-        "node_modules/node-loader": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-2.0.0.tgz",
-            "integrity": "sha512-I5VN34NO4/5UYJaUBtkrODPWxbobrE4hgDqPrjB25yPkonFhCmZ146vTH+Zg417E9Iwoh1l/MbRs1apc5J295Q==",
-            "dev": true,
-            "dependencies": {
-                "loader-utils": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
             }
         },
         "node_modules/node-releases": {
@@ -7748,7 +7570,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -7772,7 +7594,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7781,7 +7603,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7875,6 +7697,7 @@
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
             "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7992,7 +7815,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -8394,7 +8217,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
             "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -8439,7 +8262,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -8471,7 +8294,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -8510,6 +8333,7 @@
             "version": "6.10.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
             "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -8553,7 +8377,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -8568,7 +8392,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8664,7 +8488,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8679,7 +8503,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -8968,6 +8792,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9054,7 +8879,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/set-value": {
             "version": "2.0.1",
@@ -9156,6 +8981,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -9169,13 +8995,13 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
             "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9195,7 +9021,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
             "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -9638,15 +9464,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-            "engines": {
-                "node": ">=4",
-                "npm": ">=6"
-            }
-        },
         "node_modules/stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -9676,7 +9493,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9690,7 +9507,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9699,7 +9516,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -9900,7 +9717,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -9912,7 +9729,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -9928,7 +9745,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -10549,7 +10366,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -11372,36 +11189,44 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.48.5",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.5.tgz",
-            "integrity": "sha512-we0PKr2jggI2OJtua/A//Kck3Z3SCbCmg5TVKBAF8RWL5oLFLoK9b2HWoNWMUau62gbrdOa5U1CRaMJol4VlQA==",
+            "version": "0.50.0",
+            "resolved": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.50.0.tgz",
+            "integrity": "sha512-HQv7msPqqGLNHrWZiXIC8aFPuDVgtAadoEFC12VCbZHgRZbYtATAmCYADZVc9AzkCyOQ4bSUgpk2DqdXmmTPuw==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-storage": "^15.0.0",
+                "@azure/arm-resources-subscriptions": "^1.0.0",
+                "@azure/arm-storage": "^17.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
+                "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.3.1",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             }
         },
         "node_modules/vscode-azureextensionui/node_modules/@azure/arm-resources": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-            "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.0.tgz",
+            "integrity": "sha512-eKICohMfZcW0d7tsxS29Z/bznvfUMCu+khJhDJfDlKLqfmqBun6CxBTDeWcNbuckDRxalJ0gZJp5hidC9+Msiw==",
             "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
@@ -11420,13 +11245,10 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw==",
-            "engines": {
-                "vscode": "^1.5.0"
-            }
+        "node_modules/vscode-azureextensionui/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/vscode-nls": {
             "version": "4.1.2",
@@ -11722,7 +11544,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2"
             }
@@ -11786,7 +11608,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/xml": {
             "version": "1.0.1",
@@ -12054,14 +11876,36 @@
                 "tslib": "^1.10.0"
             }
         },
-        "@azure/arm-storage": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
-            "integrity": "sha512-djN2tmEzvC4lNEYrk3PAXkf5ZcebGDqPZSh/cYKOleumD4eop5EpMX8d5LcSO/9EcSfPpCzutRg0AleMaPQ9Mg==",
+        "@azure/arm-resources-subscriptions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
             "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
+            }
+        },
+        "@azure/arm-storage": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.0.0.tgz",
+            "integrity": "sha512-WS9eT3/vDQ7a1z/8K5BkPhoAi0ilo94yCSws4KyWq6UIA3RaXBDpYYAlN0TOxad9rPeOnWXWcB9gLw3DmjZ4wg==",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
             }
         },
         "@azure/arm-storage-profile-2020-09-01-hybrid": {
@@ -12079,6 +11923,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
             "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "dev": true,
             "requires": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -12137,25 +11982,6 @@
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-rest-pipeline": "^1.4.0",
                 "@azure/core-tracing": "1.0.0-preview.13",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-                }
-            }
-        },
-        "@azure/core-lro": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
-            "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
-                "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "dependencies": {
@@ -12239,55 +12065,6 @@
                 }
             }
         },
-        "@azure/identity": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-1.5.2.tgz",
-            "integrity": "sha512-vqyeRbd2i0h9F4mqW5JbkP1xfabqKQ21l/81osKhpOQ2LtwaJW6nw4+0PsVYnxcbPHFCIZt6EWAk74a3OGYZJA==",
-            "requires": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "1.0.0-preview.12",
-                "@azure/logger": "^1.0.0",
-                "@azure/msal-node": "1.0.0-beta.6",
-                "@types/stoppable": "^1.1.0",
-                "axios": "^0.21.1",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "keytar": "^7.3.0",
-                "msal": "^1.0.2",
-                "open": "^7.0.0",
-                "qs": "^6.7.0",
-                "stoppable": "^1.1.0",
-                "tslib": "^2.0.0",
-                "uuid": "^8.3.0"
-            },
-            "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.0-preview.12",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
-                    "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
-                    "requires": {
-                        "@opentelemetry/api": "^1.0.0",
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "open": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-                    "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-                    "requires": {
-                        "is-docker": "^2.0.0",
-                        "is-wsl": "^2.1.1"
-                    }
-                },
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-                }
-            }
-        },
         "@azure/loganalytics": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
@@ -12364,25 +12141,6 @@
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
                 "adal-node": "^0.2.2"
-            }
-        },
-        "@azure/msal-common": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-            "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
-            "requires": {
-                "debug": "^4.1.1"
-            }
-        },
-        "@azure/msal-node": {
-            "version": "1.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.0.0-beta.6.tgz",
-            "integrity": "sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==",
-            "requires": {
-                "@azure/msal-common": "^4.0.0",
-                "axios": "^0.21.1",
-                "jsonwebtoken": "^8.5.1",
-                "uuid": "^8.3.0"
             }
         },
         "@babel/code-frame": {
@@ -12701,7 +12459,8 @@
         "@types/node": {
             "version": "14.17.33",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
+            "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+            "dev": true
         },
         "@types/semver": {
             "version": "7.3.9",
@@ -12714,14 +12473,6 @@
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
             "dev": true
-        },
-        "@types/stoppable": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
-            "integrity": "sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==",
-            "requires": {
-                "@types/node": "*"
-            }
         },
         "@types/tapable": {
             "version": "1.0.8",
@@ -12914,6 +12665,11 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "@vscode/extension-telemetry": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.7.tgz",
+            "integrity": "sha512-tXjChgxFN6EAfa6LIy/PE3fIbIvj0BnELUmGAG+8tUpsLY3g2iACcVM/UJJXtsU6db29tMqCLITUX2Dd3N06GA=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -13264,7 +13020,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "devOptional": true
+            "dev": true
         },
         "archy": {
             "version": "1.0.0",
@@ -13276,7 +13032,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
             "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -13496,6 +13252,7 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
             "requires": {
                 "follow-redirects": "^1.14.0"
             }
@@ -13563,7 +13320,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "devOptional": true
+            "dev": true
         },
         "big-integer": {
             "version": "1.6.51",
@@ -13607,7 +13364,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -13618,7 +13375,7 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "devOptional": true,
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -13681,7 +13438,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -13702,7 +13459,8 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "dev": true
         },
         "buffer-from": {
             "version": "1.1.2",
@@ -13783,6 +13541,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
             "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
@@ -13887,7 +13646,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "devOptional": true
+            "dev": true
         },
         "chrome-trace-event": {
             "version": "1.0.3",
@@ -14074,7 +13833,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "devOptional": true
+            "dev": true
         },
         "collection-map": {
             "version": "1.0.0",
@@ -14172,7 +13931,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "devOptional": true
+            "dev": true
         },
         "convert-source-map": {
             "version": "1.8.0",
@@ -14241,7 +14000,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "devOptional": true
+            "dev": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -14324,7 +14083,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
             "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "mimic-response": "^2.0.0"
             }
@@ -14333,7 +14092,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "devOptional": true
+            "dev": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -14451,7 +14210,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "devOptional": true
+            "dev": true
         },
         "denodeify": {
             "version": "1.2.1",
@@ -14469,7 +14228,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "devOptional": true
+            "dev": true
         },
         "diff": {
             "version": "5.0.0",
@@ -14578,6 +14337,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -14604,7 +14364,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -15018,7 +14778,8 @@
         "events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true
         },
         "execa": {
             "version": "5.1.1",
@@ -15148,7 +14909,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "devOptional": true
+            "dev": true
         },
         "expand-tilde": {
             "version": "2.0.2",
@@ -15580,7 +15341,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "devOptional": true
+            "dev": true
         },
         "fs-extra": {
             "version": "8.1.0",
@@ -15651,7 +15412,8 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -15663,7 +15425,7 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -15679,13 +15441,13 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "devOptional": true
+                    "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "devOptional": true,
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -15702,6 +15464,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
             "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
@@ -15734,7 +15497,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "devOptional": true
+            "dev": true
         },
         "glob": {
             "version": "7.2.0",
@@ -16176,6 +15939,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -16195,7 +15959,8 @@
         "has-symbols": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "dev": true
         },
         "has-tostringtag": {
             "version": "1.0.0",
@@ -16210,7 +15975,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "devOptional": true
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -16418,7 +16183,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "devOptional": true
+            "dev": true
         },
         "ignore": {
             "version": "5.1.9",
@@ -16483,7 +16248,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
+            "dev": true
         },
         "internal-slot": {
             "version": "1.0.3",
@@ -16675,7 +16440,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -16849,7 +16614,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "devOptional": true
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -16937,79 +16702,17 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-            "requires": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^5.6.0"
-            },
-            "dependencies": {
-                "jwa": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-                    "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-                    "requires": {
-                        "buffer-equal-constant-time": "1.0.1",
-                        "ecdsa-sig-formatter": "1.0.11",
-                        "safe-buffer": "^5.0.1"
-                    }
-                },
-                "jws": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-                    "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-                    "requires": {
-                        "jwa": "^1.4.1",
-                        "safe-buffer": "^5.0.1"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-            }
-        },
         "just-debounce": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
             "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
             "dev": true
         },
-        "jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "requires": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "keytar": {
             "version": "7.7.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
             "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "node-addon-api": "^3.0.0",
                 "prebuild-install": "^6.0.0"
@@ -17189,46 +16892,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-        },
-        "lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-        },
-        "lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-        },
-        "lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-        },
-        "lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lodash.truncate": {
             "version": "4.4.2",
@@ -17557,7 +17225,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
             "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "devOptional": true
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -17642,7 +17310,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "devOptional": true
+            "dev": true
         },
         "mocha": {
             "version": "8.4.0",
@@ -17919,14 +17587,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "msal": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.15.tgz",
-            "integrity": "sha512-H/CxkeZJ4laEK6GZ/cDKQoYjBTvDNFK3hDC8mfU8IkuZvKFfFdo9KM89r8spXY7xnBK9SQBAjIuQgwUogeUw7g==",
-            "requires": {
-                "tslib": "^1.9.3"
-            }
-        },
         "mute-stdout": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
@@ -17983,7 +17643,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
             "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "devOptional": true
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -18007,7 +17667,7 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
             "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "semver": "^5.4.1"
             },
@@ -18016,7 +17676,7 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "devOptional": true
+                    "dev": true
                 }
             }
         },
@@ -18024,7 +17684,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-            "devOptional": true
+            "dev": true
         },
         "node-fetch": {
             "version": "2.6.6",
@@ -18032,15 +17692,6 @@
             "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
             "requires": {
                 "whatwg-url": "^5.0.0"
-            }
-        },
-        "node-loader": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-2.0.0.tgz",
-            "integrity": "sha512-I5VN34NO4/5UYJaUBtkrODPWxbobrE4hgDqPrjB25yPkonFhCmZ146vTH+Zg417E9Iwoh1l/MbRs1apc5J295Q==",
-            "dev": true,
-            "requires": {
-                "loader-utils": "^2.0.0"
             }
         },
         "node-releases": {
@@ -18103,7 +17754,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -18124,13 +17775,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "devOptional": true
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "devOptional": true
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
@@ -18203,7 +17854,8 @@
         "object-inspect": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "dev": true
         },
         "object-keys": {
             "version": "1.1.1",
@@ -18288,7 +17940,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -18580,7 +18232,7 @@
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "^4.0.0"
             }
         },
         "posix-character-classes": {
@@ -18593,7 +18245,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
             "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -18626,7 +18278,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "devOptional": true
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -18655,7 +18307,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -18693,6 +18345,7 @@
             "version": "6.10.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
             "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "dev": true,
             "requires": {
                 "side-channel": "^1.0.4"
             }
@@ -18716,7 +18369,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -18728,7 +18381,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "devOptional": true
+                    "dev": true
                 }
             }
         },
@@ -18806,7 +18459,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -18821,7 +18474,7 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "devOptional": true
+                    "dev": true
                 }
             }
         },
@@ -19025,7 +18678,8 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -19082,7 +18736,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "devOptional": true
+            "dev": true
         },
         "set-value": {
             "version": "2.0.1",
@@ -19164,6 +18818,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -19174,19 +18829,19 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
             "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-            "devOptional": true
+            "dev": true
         },
         "simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "devOptional": true
+            "dev": true
         },
         "simple-get": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
             "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -19555,11 +19210,6 @@
                 }
             }
         },
-        "stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-        },
         "stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -19591,7 +19241,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19602,13 +19252,13 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "devOptional": true
+                    "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "devOptional": true,
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -19775,7 +19425,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -19787,7 +19437,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -19800,7 +19450,7 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "devOptional": true,
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -20268,7 +19918,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -20967,36 +20617,39 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.48.5",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.5.tgz",
-            "integrity": "sha512-we0PKr2jggI2OJtua/A//Kck3Z3SCbCmg5TVKBAF8RWL5oLFLoK9b2HWoNWMUau62gbrdOa5U1CRaMJol4VlQA==",
+            "version": "file:..\\vscode-azuretools\\ui\\vscode-azureextensionui-0.50.0.tgz",
+            "integrity": "sha512-HQv7msPqqGLNHrWZiXIC8aFPuDVgtAadoEFC12VCbZHgRZbYtATAmCYADZVc9AzkCyOQ4bSUgpk2DqdXmmTPuw==",
             "requires": {
-                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-storage": "^15.0.0",
+                "@azure/arm-resources-subscriptions": "^1.0.0",
+                "@azure/arm-storage": "^17.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
+                "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.3.1",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             },
             "dependencies": {
                 "@azure/arm-resources": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-                    "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.0.tgz",
+                    "integrity": "sha512-eKICohMfZcW0d7tsxS29Z/bznvfUMCu+khJhDJfDlKLqfmqBun6CxBTDeWcNbuckDRxalJ0gZJp5hidC9+Msiw==",
                     "requires": {
-                        "@azure/ms-rest-azure-js": "^2.0.1",
-                        "@azure/ms-rest-js": "^2.0.4",
-                        "tslib": "^1.10.0"
+                        "@azure/abort-controller": "^1.0.0",
+                        "@azure/core-auth": "^1.3.0",
+                        "@azure/core-client": "^1.0.0",
+                        "@azure/core-lro": "^2.2.0",
+                        "@azure/core-paging": "^1.2.0",
+                        "@azure/core-rest-pipeline": "^1.1.0",
+                        "tslib": "^2.2.0"
                     }
                 },
                 "escape-string-regexp": {
@@ -21008,13 +20661,13 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
                 }
             }
-        },
-        "vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw=="
         },
         "vscode-nls": {
             "version": "4.1.2",
@@ -21042,9 +20695,9 @@
             }
         },
         "watchpack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -21076,7 +20729,7 @@
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
+                "graceful-fs": "^4.2.9",
                 "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
@@ -21089,9 +20742,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+                    "version": "8.7.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
                     "dev": true
                 },
                 "acorn-import-assertions": {
@@ -21229,7 +20882,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
             }
@@ -21283,7 +20936,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "devOptional": true
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -180,32 +180,32 @@
                 {
                     "command": "containerApps.refresh",
                     "when": "view == containerApps && viewItem =~ /azureSubscription|kubeEnvironment|containerApp/",
-                    "group": "z@1"
+                    "group": "z@2"
                 },
                 {
                     "command": "containerApps.createKubeEnvironment",
                     "when": "view == containerApps && viewItem =~ /azureSubscription/",
-                    "group": "1@1"
+                    "group": "2@1"
                 },
                 {
                     "command": "containerApps.createContainerApp",
                     "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
-                    "group": "1@1"
+                    "group": "2@1"
                 },
                 {
                     "command": "containerApps.deleteKubeEnvironment",
                     "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
-                    "group": "2@1"
+                    "group": "3@1"
                 },
                 {
                     "command": "containerApps.deployImage",
                     "when": "view == containerApps && viewItem =~ /containerApp/",
-                    "group": "1@1"
+                    "group": "2@1"
                 },
                 {
                     "command": "containerApps.deleteContainerApp",
                     "when": "view == containerApps && viewItem =~ /containerApp/",
-                    "group": "2@1"
+                    "group": "3@1"
                 },
                 {
                     "command": "containerApps.chooseRevisionMode",
@@ -250,12 +250,12 @@
                 {
                     "command": "containerApps.viewProperties",
                     "when": "view == containerApps && viewItem =~ /azResource/",
-                    "group": "2@1"
+                    "group": "z@1"
                 },
                 {
                     "command": "containerApps.openInPortal",
                     "when": "view == containerApps && viewItem =~ /kubeEnvironment|containerApp/",
-                    "group": "2@2"
+                    "group": "1@1"
                 }
             ],
             "commandPalette": [
@@ -282,6 +282,19 @@
                         "description": "%containerApps.enableOutputTimestamps%",
                         "default": true
                     }
+                },
+                "containerApps.deleteConfirmation": {
+                    "type": "string",
+                    "enum": [
+                        "EnterName",
+                        "ClickButton"
+                    ],
+                    "description": "%containerApps.deleteConfirmation%",
+                    "enumDescriptions": [
+                        "%containerApps.deleteConfirmation.EnterName%",
+                        "%containerApps.deleteConfirmation.ClickButton%"
+                    ],
+                    "default": "EnterName"
                 }
             }
         ]
@@ -326,7 +339,6 @@
         "mocha": "^8.3.2",
         "mocha-junit-reporter": "^2.0.0",
         "mocha-multi-reporters": "^1.1.7",
-        "node-loader": "^2.0.0",
         "ts-node": "^7.0.1",
         "typescript": "^4.3.5",
         "vsce": "^1.87.1",
@@ -341,12 +353,11 @@
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",
         "@azure/container-registry": "^1.0.0-beta.5",
-        "@azure/identity": "^1.5.2",
         "@azure/loganalytics": "^0.3.0",
         "@azure/ms-rest-js": "^2.2.1",
         "open": "^8.0.4",
         "semver": "^7.3.5",
-        "vscode-azureextensionui": "0.48.5",
+        "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.50.0.tgz",
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "onCommand:containerApps.openInPortal",
         "onCommand:containerApps.createContainerApp",
         "onCommand:containerApps.deployImage",
+        "onCommand:containerApps.deleteKubeEnvironment",
         "onCommand:containerApps.deleteContainerApp",
         "onCommand:containerApps.openLogs",
         "onCommand:containerApps.disableIngress",
@@ -91,6 +92,11 @@
             {
                 "command": "containerApps.deployImage",
                 "title": "%containerApps.deployImage%",
+                "category": "Azure Container Apps"
+            },
+            {
+                "command": "containerApps.deleteKubeEnvironment",
+                "title": "%containerApps.deleteKubeEnvironment%",
                 "category": "Azure Container Apps"
             },
             {
@@ -185,6 +191,11 @@
                     "command": "containerApps.createContainerApp",
                     "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
                     "group": "1@1"
+                },
+                {
+                    "command": "containerApps.deleteKubeEnvironment",
+                    "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
+                    "group": "2@1"
                 },
                 {
                     "command": "containerApps.deployImage",

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,4 +22,7 @@
     "containerApps.restartRevision": "Restart",
     "containerApps.createKubeEnvironment": "Create Container App Environment...",
     "containerApps.deleteKubeEnvironment": "Delete Container App Environment...",
+    "containerApps.deleteConfirmation": "The behavior to use when confirming delete of a Container App environment.",
+    "containerApps.deleteConfirmation.EnterName": "Prompts with an input box where you enter the Container App enviornment name to delete.",
+    "containerApps.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,5 +20,6 @@
     "containerApps.activateRevision": "Activate",
     "containerApps.deactivateRevision": "Deactivate",
     "containerApps.restartRevision": "Restart",
-    "containerApps.createKubeEnvironment": "Create Container App Environment..."
+    "containerApps.createKubeEnvironment": "Create Container App Environment...",
+    "containerApps.deleteKubeEnvironment": "Delete Container App Environment...",
 }

--- a/src/commands/createKubeEnvironment/KubeEnvironmentCreateStep.ts
+++ b/src/commands/createKubeEnvironment/KubeEnvironmentCreateStep.ts
@@ -18,7 +18,7 @@ export class KubeEnvironmentCreateStep extends AzureWizardExecuteStep<IKubeEnvir
 
     public async execute(context: IKubeEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const client: WebSiteManagementClient = await createWebSiteClient(context);
-        const opClient = createOperationalInsightsManagementClient(context);
+        const opClient = await createOperationalInsightsManagementClient(context);
         const rgName = nonNullValueAndProp(context.resourceGroup, 'name');
         const logAnalyticsWorkspace = nonNullProp(context, 'logAnalyticsWorkspace');
 

--- a/src/commands/createKubeEnvironment/LogAnalyticsCreateStep.ts
+++ b/src/commands/createKubeEnvironment/LogAnalyticsCreateStep.ts
@@ -15,7 +15,7 @@ export class LogAnalyticsCreateStep extends AzureWizardExecuteStep<IKubeEnvironm
     public priority: number = 200;
 
     public async execute(context: IKubeEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        const opClient = createOperationalInsightsManagementClient(context);
+        const opClient = await createOperationalInsightsManagementClient(context);
         const rg = nonNullValue(context.resourceGroup);
 
         const creatingLaw: string = localize('creatingLogAnalyticWorkspace', 'Creating new Log Analytic workspace...');

--- a/src/commands/createKubeEnvironment/LogAnalyticsListStep.ts
+++ b/src/commands/createKubeEnvironment/LogAnalyticsListStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Workspace } from '@azure/arm-operationalinsights';
-import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureQuickPickItem, uiUtils } from 'vscode-azureextensionui';
 import { createOperationalInsightsManagementClient } from '../../utils/azureClients';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
@@ -29,14 +29,10 @@ export class LogAnalyticsListStep extends AzureWizardPromptStep<IKubeEnvironment
             data: undefined
         });
 
-        const opClient = createOperationalInsightsManagementClient(context);
+        const opClient = await createOperationalInsightsManagementClient(context);
 
-        const workspaces: Workspace[] = [];
-        // could be more efficient to call this once at Subscription level, and filter based off that
-        // but then risk stale data
-        for await (const ws of opClient.workspaces.list()) {
-            workspaces.push(ws);
-        }
+        const workspaces: Workspace[] = await uiUtils.listAllIterator(opClient.workspaces.list);
+
         return picks.concat(workspaces.map(ws => {
             return { label: nonNullProp(ws, 'name'), data: ws }
         }));

--- a/src/commands/createKubeEnvironment/createKubeEnvironment.ts
+++ b/src/commands/createKubeEnvironment/createKubeEnvironment.ts
@@ -9,7 +9,6 @@ import { ext } from "../../extensionVariables";
 import { KubeEnvironmentTreeItem } from "../../tree/KubeEnvironmentTreeItem";
 import { SubscriptionTreeItem } from "../../tree/SubscriptionTreeItem";
 import { localize } from "../../utils/localize";
-import { nonNullProp } from "../../utils/nonNull";
 import { IKubeEnvironmentContext } from "./IKubeEnvironmentContext";
 
 export async function createKubeEnvironment(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IKubeEnvironmentContext>, node?: SubscriptionTreeItem): Promise<KubeEnvironmentTreeItem> {
@@ -18,7 +17,7 @@ export async function createKubeEnvironment(context: IActionContext & Partial<IC
     }
 
     const keNode: KubeEnvironmentTreeItem = await node.createChild(context);
-    const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container App environment "{0}".', nonNullProp(context, 'newKubeEnvironmentName'));
+    const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container App environment "{0}".', keNode.name);
     ext.outputChannel.appendLog(createdKuEnv);
     void window.showInformationMessage(createdKuEnv);
 

--- a/src/commands/deployImage/acr/AcrRepositoriesListStep.ts
+++ b/src/commands/deployImage/acr/AcrRepositoriesListStep.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { QuickPickItem } from "vscode";
+import { uiUtils } from "vscode-azureextensionui";
 import { createContainerRegistryClient } from "../../../utils/azureClients";
 import { nonNullValue } from "../../../utils/nonNull";
 import { IDeployImageContext } from "../IDeployImageContext";
@@ -11,12 +12,8 @@ import { RegistryRepositoriesListStepBase } from "../RegistryRepositoriesListBas
 
 export class AcrRepositoriesListStep extends RegistryRepositoriesListStepBase {
     public async getPicks(context: IDeployImageContext): Promise<QuickPickItem[]> {
-        const client = createContainerRegistryClient(nonNullValue(context.registry));
-        const repositoryNames: string[] = []
-
-        for await (const repository of client.listRepositoryNames()) {
-            repositoryNames.push(repository);
-        }
+        const client = createContainerRegistryClient(context, nonNullValue(context.registry));
+        const repositoryNames: string[] = await uiUtils.listAllIterator(client.listRepositoryNames);
 
         return repositoryNames.map((rn) => { return { label: rn } });
     }

--- a/src/commands/deployImage/acr/AcrTagListStep.ts
+++ b/src/commands/deployImage/acr/AcrTagListStep.ts
@@ -5,6 +5,7 @@
 
 import { ArtifactManifestProperties } from "@azure/container-registry";
 import { QuickPickItem } from "vscode";
+import { uiUtils } from "vscode-azureextensionui";
 import { createContainerRegistryClient } from "../../../utils/azureClients";
 import { nonNullProp, nonNullValue } from "../../../utils/nonNull";
 import { IDeployImageContext } from "../IDeployImageContext";
@@ -12,13 +13,10 @@ import { RepositoryTagListStepBase } from "../RepositoryTagListStepBase";
 
 export class AcrTagListStep extends RepositoryTagListStepBase {
     public async getPicks(context: IDeployImageContext): Promise<QuickPickItem[]> {
-        const client = createContainerRegistryClient(nonNullValue(context.registry));
-        const manifests: ArtifactManifestProperties[] = [];
+        const client = createContainerRegistryClient(context, nonNullValue(context.registry));
+        const repoClient = client.getRepository(nonNullProp(context, 'repositoryName'));
 
-        for await (const manifest of client.getRepository(nonNullProp(context, 'repositoryName')).listManifestProperties()) {
-            manifests.push(manifest);
-        }
-
+        const manifests: ArtifactManifestProperties[] = await uiUtils.listAllIterator(repoClient.listManifestProperties);
         return manifests[0].tags.map((t) => { { return { label: t } } });
     }
 }

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -5,6 +5,7 @@
 
 import * as ui from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
+import { ContainerAppTreeItem } from '../tree/ContainerAppTreeItem';
 import { KubeEnvironmentTreeItem } from '../tree/KubeEnvironmentTreeItem';
 
 export async function openInPortal(context: ui.IActionContext, node?: ui.AzExtTreeItem): Promise<void> {
@@ -12,6 +13,12 @@ export async function openInPortal(context: ui.IActionContext, node?: ui.AzExtTr
         node = await ext.tree.showTreeItemPicker<KubeEnvironmentTreeItem>(KubeEnvironmentTreeItem.contextValue, context);
     }
 
-    await ui.openInPortal(node, node.fullId);
+    if (node instanceof ContainerAppTreeItem) {
+        // ContainerApp's id don't include the KubeEnvironment (ie the parent) so don't use fullId
+        await ui.openInPortal(node, <string>node.data.id);
+    } else {
+        await ui.openInPortal(node, node.fullId);
+    }
+
 
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -23,7 +23,6 @@ import { changeRevisionActiveState } from './revisionCommands/changeRevisionActi
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
-
     registerCommand('containerApps.loadMore', async (context: IActionContext, node: AzExtTreeItem) => await ext.tree.loadMore(node, context));
     registerCommand('containerApps.openInPortal', openInPortal);
     registerCommand('containerApps.refresh', async (context: IActionContext, node?: AzExtTreeItem) => await ext.tree.refresh(context, node));

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -7,6 +7,7 @@ import { commands } from 'vscode';
 import { AzExtTreeItem, IActionContext, registerCommand, registerErrorHandler, registerReportIssueCommand } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { ContainerAppTreeItem } from '../tree/ContainerAppTreeItem';
+import { KubeEnvironmentTreeItem } from '../tree/KubeEnvironmentTreeItem';
 import { RevisionTreeItem } from '../tree/RevisionTreeItem';
 import { SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
 import { browse } from './browse';
@@ -32,6 +33,7 @@ export function registerCommands(): void {
     registerCommand('containerApps.createKubeEnvironment', createKubeEnvironment);
     registerCommand('containerApps.createContainerApp', createContainerApp);
     registerCommand('containerApps.deployImage', deployImage);
+    registerCommand('containerApps.deleteKubeEnvironment', async (context: IActionContext, node?: KubeEnvironmentTreeItem) => await deleteNode(context, KubeEnvironmentTreeItem.contextValue, node));
     registerCommand('containerApps.deleteContainerApp', async (context: IActionContext, node?: ContainerAppTreeItem) => await deleteNode(context, ContainerAppTreeItem.contextValue, node));
     registerCommand('containerApps.openLogs', openLogs);
     registerCommand('containerApps.enableIngress', toggleIngress);

--- a/src/commands/revisionCommands/changeRevisionActiveState.ts
+++ b/src/commands/revisionCommands/changeRevisionActiveState.ts
@@ -12,7 +12,6 @@ import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
 
 export async function changeRevisionActiveState(context: IActionContext, command: 'activate' | 'deactivate' | 'restart', node?: RevisionTreeItem): Promise<void> {
-
     if (!node) {
         node = await ext.tree.showTreeItemPicker<RevisionTreeItem>(RevisionTreeItem.contextValue, context);
     }

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -88,7 +88,8 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
             } catch (error) {
                 const pError = parseError(error);
                 // a 204 indicates a success, but sdk is catching it as an exception
-                if (pError.errorType !== '204') {
+                // accept any 2xx reponse code
+                if (Number(pError.errorType) < 200 || Number(pError.errorType) >= 300) {
                     throw error;
                 }
             }

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -135,6 +135,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
             queryParameters: { 'api-version': '2021-03-01' },
             pathTemplate: `${this.id}/listSecrets`,
         };
+
         const response = await sendRequestWithTimeout(context, options, 5000, this.subscription.credentials);
         // if 204, needs to be an empty []
         concreteContainerAppEnvelope.configuration.secrets = response.status === 204 ? [] : <Secret[]>response.parsedBody;

--- a/src/tree/KubeEnvironmentTreeItem.ts
+++ b/src/tree/KubeEnvironmentTreeItem.ts
@@ -21,10 +21,6 @@ import { settingUtils } from "../utils/settingUtils";
 import { treeUtils } from "../utils/treeUtils";
 import { ContainerAppTreeItem } from "./ContainerAppTreeItem";
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
-<<<<<<< HEAD
-=======
-import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, DialogResponses, IActionContext, ICreateChildImplContext, LocationListStep, parseError, TreeItemIconPath, VerifyProvidersStep } from "vscode-azureextensionui";
->>>>>>> efefe1438395e2d9f254b82be51b6651da50cdab
 
 export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
     public static contextValue: string = 'kubeEnvironment|azResource';

--- a/src/tree/KubeEnvironmentTreeItem.ts
+++ b/src/tree/KubeEnvironmentTreeItem.ts
@@ -109,7 +109,7 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
                 const pError = parseError(error);
                 // a 204 indicates a success, but sdk is catching it as an exception:
                 // Received unexpected HTTP status code 204 while polling. This may indicate a server issue.
-                if (pError.errorType !== '204') {
+                if (Number(pError.errorType) < 200 || Number(pError.errorType) >= 300) {
                     throw error;
                 }
             }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KubeEnvironment, WebSiteManagementClient } from '@azure/arm-appservice';
-import { AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ICreateChildImplContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ICreateChildImplContext, LocationListStep, ResourceGroupCreateStep, SubscriptionTreeItemBase, uiUtils } from 'vscode-azureextensionui';
 import { IKubeEnvironmentContext } from '../commands/createKubeEnvironment/IKubeEnvironmentContext';
 import { KubeEnvironmentCreateStep } from '../commands/createKubeEnvironment/KubeEnvironmentCreateStep';
 import { KubeEnvironmentNameStep } from '../commands/createKubeEnvironment/KubeEnvironmentNameStep';
 import { LogAnalyticsCreateStep } from '../commands/createKubeEnvironment/LogAnalyticsCreateStep';
-import { LogAnalyticsListStep } from '../commands/createKubeEnvironment/LogAnalyticsListStep';
 import { createWebSiteClient } from '../utils/azureClients';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -25,11 +24,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
-        const environments: KubeEnvironment[] = [];
-
-        for await (const env of client.kubeEnvironments.listBySubscription()) {
-            environments.push(env);
-        }
+        const environments: KubeEnvironment[] = await uiUtils.listAllIterator(client.kubeEnvironments.listBySubscription);
 
         return await this.createTreeItemsWithErrorHandling(
             environments,
@@ -37,7 +32,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             ke => new KubeEnvironmentTreeItem(this, ke),
             ke => ke.name
         );
-
     }
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
@@ -47,8 +41,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const promptSteps: AzureWizardPromptStep<IKubeEnvironmentContext>[] = [];
         const executeSteps: AzureWizardExecuteStep<IKubeEnvironmentContext>[] = [];
 
-        promptSteps.push(new ResourceGroupListStep(), new KubeEnvironmentNameStep(), new LogAnalyticsListStep());
-        executeSteps.push(new LogAnalyticsCreateStep(), new KubeEnvironmentCreateStep());
+        promptSteps.push(new KubeEnvironmentNameStep());
+        executeSteps.push(new ResourceGroupCreateStep(), new LogAnalyticsCreateStep(), new KubeEnvironmentCreateStep());
         LocationListStep.addProviderForFiltering(wizardContext, 'Microsoft.Web', 'kubeEnvironments');
         LocationListStep.addStep(wizardContext, promptSteps);
 
@@ -60,7 +54,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         });
 
         await wizard.prompt();
-        context.showCreatingTreeItem(nonNullProp(wizardContext, 'newKubeEnvironmentName'));
+        const newKubeEnvName = nonNullProp(wizardContext, 'newKubeEnvironmentName');
+        context.showCreatingTreeItem(newKubeEnvName);
+        wizardContext.newResourceGroupName = newKubeEnvName;
         await wizard.execute();
 
         return new KubeEnvironmentTreeItem(this, nonNullProp(wizardContext, 'kubeEnvironment'));

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -7,43 +7,31 @@ import { WebSiteManagementClient } from '@azure/arm-appservice';
 import { ContainerRegistryManagementClient, ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { OperationalInsightsManagementClient } from '@azure/arm-operationalinsights';
 import { ContainerRegistryClient, KnownContainerRegistryAudience } from '@azure/container-registry';
-import { VisualStudioCodeCredential } from '@azure/identity';
 import { LogAnalyticsClient } from '@azure/loganalytics';
-import { appendExtensionUserAgent, AzExtClientContext, parseClientContext } from 'vscode-azureextensionui';
+import { AzExtClientContext, createAzureClient, parseClientContext } from 'vscode-azureextensionui';
 
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
 export async function createWebSiteClient(context: AzExtClientContext): Promise<WebSiteManagementClient> {
-    const clientContext = parseClientContext(context);
-    const cred = new VisualStudioCodeCredential({ tenantId: clientContext.tenantId })
-    return new WebSiteManagementClient(cred, clientContext.subscriptionId,
-        {
-            endpoint: 'https://brazilus.management.azure.com/',
-            userAgentOptions: { userAgentPrefix: appendExtensionUserAgent() }
-        });
+    return createAzureClient(context, (await import('@azure/arm-appservice')).WebSiteManagementClient);
 }
 
 export async function createContainerRegistryManagementClient(context: AzExtClientContext): Promise<ContainerRegistryManagementClient> {
-    const clientContext = parseClientContext(context);
-    const cred = new VisualStudioCodeCredential({ tenantId: clientContext.tenantId })
-    return new ContainerRegistryManagementClient(cred, clientContext.subscriptionId);
+    return createAzureClient(context, (await import('@azure/arm-containerregistry')).ContainerRegistryManagementClient);
 }
 
-export function createContainerRegistryClient(registry: ContainerRegistryManagementModels.Registry): ContainerRegistryClient {
-    return new ContainerRegistryClient(`https://${registry.loginServer}`, new VisualStudioCodeCredential({}),
+export function createContainerRegistryClient(context: AzExtClientContext, registry: ContainerRegistryManagementModels.Registry): ContainerRegistryClient {
+    const clientContext = parseClientContext(context);
+    return new ContainerRegistryClient(`https://${registry.loginServer}`, clientContext.credentials,
         { audience: KnownContainerRegistryAudience.AzureResourceManagerPublicCloud });
 }
-
-
 
 export function createLogAnalyticsClient(context: AzExtClientContext): LogAnalyticsClient {
     const clientContext = parseClientContext(context);
     return new LogAnalyticsClient(clientContext.credentials);
 }
 
-export function createOperationalInsightsManagementClient(context: AzExtClientContext): OperationalInsightsManagementClient {
-    const clientContext = parseClientContext(context);
-    const cred = new VisualStudioCodeCredential({ tenantId: clientContext.tenantId })
-    return new OperationalInsightsManagementClient(cred, clientContext.subscriptionId);
+export async function createOperationalInsightsManagementClient(context: AzExtClientContext): Promise<OperationalInsightsManagementClient> {
+    return createAzureClient(context, (await import('@azure/arm-operationalinsights')).OperationalInsightsManagementClient);
 }

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { ext } from "../extensionVariables";
+
+export namespace settingUtils {
+    /**
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     */
+    export async function updateGlobalSetting<T = string>(section: string, value: T, prefix: string = ext.prefix): Promise<void> {
+        const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+        await projectConfiguration.update(section, value, ConfigurationTarget.Global);
+    }
+
+    /**
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     */
+    export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix): Promise<void> {
+        const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));
+        await projectConfiguration.update(section, value);
+    }
+
+    /**
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     */
+    export function getGlobalSetting<T>(key: string, prefix: string = ext.prefix): T | undefined {
+        const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+        const result: { globalValue?: T } | undefined = projectConfiguration.inspect<T>(key);
+        return result && result.globalValue;
+    }
+
+    /**
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     */
+    export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
+        const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
+        return projectConfiguration.get<T>(key);
+    }
+
+    /**
+     * Searches through all open folders and gets the current workspace setting (as long as there are no conflicts)
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     */
+    export function getWorkspaceSettingFromAnyFolder(key: string, prefix: string = ext.prefix): string | undefined {
+        if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+            let result: string | undefined;
+            for (const folder of workspace.workspaceFolders) {
+                const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, folder.uri);
+                const folderResult: string | undefined = projectConfiguration.get<string>(key);
+                if (!result) {
+                    result = folderResult;
+                } else if (folderResult && result !== folderResult) {
+                    return undefined;
+                }
+            }
+            return result;
+        } else {
+            return getGlobalSetting(key, prefix);
+        }
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,10 +16,7 @@ let DEBUG_WEBPACK = !/^(false|0)?$/i.test(process.env.DEBUG_WEBPACK || '');
 
 let config = dev.getDefaultWebpackConfig({
     projectRoot: __dirname,
-    verbosity: DEBUG_WEBPACK ? 'debug' : 'normal',
-    loaderRules: [
-        { test: /\.node$/, loader: 'node-loader', }
-    ]
+    verbosity: DEBUG_WEBPACK ? 'debug' : 'normal'
 });
 
 if (DEBUG_WEBPACK) {


### PR DESCRIPTION
PR ended up getting a bit away from me, but will break it down below
---
## T2 Azure Credentials

This PR depends on the following PRs:
  - https://github.com/microsoft/vscode-azure-account/commit/d4ec3d8e1e7dec16a03e1cb361b4e1d4f09a7a28
  - https://github.com/microsoft/vscode-azuretools/commit/d3b4e61a34908d8226b20d45881b48427e2cdd91
 
Because the Container Apps sdk is T2, I had to upgrade the credential types in order to use it.  Previously, I was getting around this using the `azure-identity` package, but this brought in a dependency on `keytar` which ended up breaking the vsix on Mac/Linux.  The changes related to getting ride of the `VisualStudioCodeCredentials` such as https://github.com/microsoft/vscode-azurecontainerapps/compare/nat/delete?expand=1#diff-17e919c422cbcd1b90fea9dac31ba7001932c46adae157768f07a1bf5cdf7b64L19 are directly related to this change.

This does mean that if Azure Accounts isn't updated, the extension won't work.  Since Azure Accounts is releasing with a new versioned API, I could check that version to throw an error for the user or I could just check the extension version and validate it.

---
## Delete KubeEnvironment

The language is still Container Apps environment as I mentioned.  If you try to delete an env that has container apps, it throws an error so to get around that, I prompt the user to delete all container apps first.  There was some feedback that it would be better to have to type the name of the container app environment before deleting since it is a pretty destructive event, so I pulled RG extension's implementation into here including the setting to change it to a button click.  Two current "issues" are
- The container app tree nodes don't have the spinner indicating they are deleting even though I call `deleteTreeItem`.  I have no idea why the UI doesn't reflect that since all of the `runWithTemporaryDescription` code is in `deleteTreeItemImpl`.
- The children of the node don't cache unless you expand the tree node which effects perf if you try to delete, cancel, and then delete again.  I don't foresee this being a _huge_ problem since I'd imagine most users would either just delete it or expand the environment first to see what apps are under it before deleting it.
---
## Creating KubeEnviornment

This has been changed to automatically create a new log workspace and resource group.  Potential issues right now are location availability between container app environment and log analytic workspaces, but I should be able to compare the available location lists.  It's just not convenient right now because I have to use the staging location to test certain features.

---

## Minor changes
- Fixed Open in Portal bug with Container Apps
- Use `uiUtils.listAllIterator` where possible (some require more parameters that I didn't account for which I can fix in the ui package)

 