### PR TITLE
Use new package for container apps due to provider migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.1-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@azure/arm-appservice": "11.0.0",
                 "@azure/arm-containerregistry": "^8.1.1",
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
@@ -64,28 +63,6 @@
             }
         },
         "node_modules/@azure/abort-controller/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/@azure/arm-appservice": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-11.0.0.tgz",
-            "integrity": "sha512-y+GllRQNlXqVR8tzzZGdzb/J+EtvIBcFD0dXSngaBkvl5+wgt+/wclJSx2xcSVZQO+yEj9YE/xG4EXkr/qb23g==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/arm-appservice/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -11809,27 +11786,6 @@
                 }
             }
         },
-        "@azure/arm-appservice": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-11.0.0.tgz",
-            "integrity": "sha512-y+GllRQNlXqVR8tzzZGdzb/J+EtvIBcFD0dXSngaBkvl5+wgt+/wclJSx2xcSVZQO+yEj9YE/xG4EXkr/qb23g==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "tslib": "^2.2.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-                }
-            }
-        },
         "@azure/arm-containerregistry": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-8.1.1.tgz",
@@ -20625,7 +20581,7 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.50.0.tgz",
+            "version": "file:..\\vscode-azuretools\\ui\\vscode-azureextensionui-0.50.0.tgz",
             "integrity": "sha512-8sGj2cEfY8tGC89iO0t1CWFnrAMxUi8BOvw9DdmG2lfOVqNMO+Wf2r/6SWBCScWw5NgYjnuNEW3EEi9GlGuTmQ==",
             "requires": {
                 "@azure/arm-resources": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
             "view/item/context": [
                 {
                     "command": "containerApps.refresh",
-                    "when": "view == containerApps && viewItem =~ /azureSubscription|ManagedEnvironment|containerApp/",
+                    "when": "view == containerApps && viewItem =~ /azureSubscription|managedEnvironment|containerApp/",
                     "group": "z@2"
                 },
                 {
@@ -195,12 +195,12 @@
                 },
                 {
                     "command": "containerApps.createContainerApp",
-                    "when": "view == containerApps && viewItem =~ /ManagedEnvironment/",
+                    "when": "view == containerApps && viewItem =~ /managedEnvironment/",
                     "group": "2@1"
                 },
                 {
                     "command": "containerApps.deleteManagedEnvironment",
-                    "when": "view == containerApps && viewItem =~ /ManagedEnvironment/",
+                    "when": "view == containerApps && viewItem =~ /managedEnvironment/",
                     "group": "3@1"
                 },
                 {
@@ -359,7 +359,6 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@azure/arm-appservice": "11.0.0",
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "onCommand:containerApps.openInPortal",
         "onCommand:containerApps.createContainerApp",
         "onCommand:containerApps.deployImage",
-        "onCommand:containerApps.deleteKubeEnvironment",
+        "onCommand:containerApps.deleteManagedEnvironment",
         "onCommand:containerApps.deleteContainerApp",
         "onCommand:containerApps.openLogs",
         "onCommand:containerApps.disableIngress",
@@ -48,7 +48,7 @@
         "onCommand:containerApps.activateRevision",
         "onCommand:containerApps.deactivateRevision",
         "onCommand:containerApps.restartRevision",
-        "onCommand:containerApps.createKubeEnvironment",
+        "onCommand:containerApps.createManagedEnvironment",
         "onCommand:containerApps.browse"
     ],
     "main": "./main.js",
@@ -96,8 +96,8 @@
                 "category": "Azure Container Apps"
             },
             {
-                "command": "containerApps.deleteKubeEnvironment",
-                "title": "%containerApps.deleteKubeEnvironment%",
+                "command": "containerApps.deleteManagedEnvironment",
+                "title": "%containerApps.deleteManagedEnvironment%",
                 "category": "Azure Container Apps"
             },
             {
@@ -151,8 +151,8 @@
                 "category": "Azure Container Apps"
             },
             {
-                "command": "containerApps.createKubeEnvironment",
-                "title": "%containerApps.createKubeEnvironment%",
+                "command": "containerApps.createManagedEnvironment",
+                "title": "%containerApps.createManagedEnvironment%",
                 "category": "Azure Container Apps"
             },
             {
@@ -185,22 +185,22 @@
             "view/item/context": [
                 {
                     "command": "containerApps.refresh",
-                    "when": "view == containerApps && viewItem =~ /azureSubscription|kubeEnvironment|containerApp/",
+                    "when": "view == containerApps && viewItem =~ /azureSubscription|ManagedEnvironment|containerApp/",
                     "group": "z@2"
                 },
                 {
-                    "command": "containerApps.createKubeEnvironment",
+                    "command": "containerApps.createManagedEnvironment",
                     "when": "view == containerApps && viewItem =~ /azureSubscription/",
                     "group": "2@1"
                 },
                 {
                     "command": "containerApps.createContainerApp",
-                    "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
+                    "when": "view == containerApps && viewItem =~ /ManagedEnvironment/",
                     "group": "2@1"
                 },
                 {
-                    "command": "containerApps.deleteKubeEnvironment",
-                    "when": "view == containerApps && viewItem =~ /kubeEnvironment/",
+                    "command": "containerApps.deleteManagedEnvironment",
+                    "when": "view == containerApps && viewItem =~ /ManagedEnvironment/",
                     "group": "3@1"
                 },
                 {
@@ -260,7 +260,7 @@
                 },
                 {
                     "command": "containerApps.openInPortal",
-                    "when": "view == containerApps && viewItem =~ /kubeEnvironment|containerApp/",
+                    "when": "view == containerApps && viewItem =~ /ManagedEnvironment|containerApp/",
                     "group": "1@1"
                 },
                 {
@@ -359,7 +359,6 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@azure/arm-appservice": "11.0.0",
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -359,6 +359,7 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
+        "@azure/arm-appservice": "11.0.0",
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,8 +21,8 @@
     "containerApps.activateRevision": "Activate",
     "containerApps.deactivateRevision": "Deactivate",
     "containerApps.restartRevision": "Restart",
-    "containerApps.createKubeEnvironment": "Create Container App Environment...",
-    "containerApps.deleteKubeEnvironment": "Delete Container App Environment...",
+    "containerApps.createManagedEnvironment": "Create Container App Environment...",
+    "containerApps.deleteManagedEnvironment": "Delete Container App Environment...",
     "containerApps.deleteConfirmation": "The behavior to use when confirming delete of a Container App environment.",
     "containerApps.deleteConfirmation.EnterName": "Prompts with an input box where you enter the Container App enviornment name to delete.",
     "containerApps.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete."

--- a/src/commands/chooseRevisionMode.ts
+++ b/src/commands/chooseRevisionMode.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerAppsAPIClient } from "@azure/arm-app";
 import { ProgressLocation, window } from "vscode";
 import { IActionContext, IAzureQuickPickItem } from "vscode-azureextensionui";
 import { RevisionConstants } from "../constants";
 import { ext } from "../extensionVariables";
 import { RevisionsTreeItem } from "../tree/RevisionsTreeItem";
-import { createWebSiteClient } from "../utils/azureClients";
+import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
 import { nonNullValue } from "../utils/nonNull";
 
@@ -29,7 +29,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Revisio
 
     if (currentModeQp !== result) {
         // only update it if it's actually different
-        const webClient: WebSiteManagementClient = await createWebSiteClient([context, node]);
+        const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
         const containerAppEnvelope = await node.parent.getContainerEnvelopeWithSecrets(context);
         const updating = localize('updatingRevision', 'Updating revision mode of "{0}" to "{1}"...', node.parent.name, result.label.toLowerCase());
         const updated = localize('updatedRevision', 'Updated revision mode of "{0}" to "{1}".', node.parent.name, result.label.toLowerCase());
@@ -42,7 +42,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Revisio
         await window.withProgress({ location: ProgressLocation.Notification, title: updating }, async (): Promise<void> => {
             const pNode = nonNullValue(node).parent;
             ext.outputChannel.appendLog(updating);
-            await webClient.containerApps.beginCreateOrUpdateAndWait(pNode.resourceGroupName, pNode.name, containerAppEnvelope);
+            await appClient.containerApps.beginCreateOrUpdateAndWait(pNode.resourceGroupName, pNode.name, containerAppEnvelope);
 
             void window.showInformationMessage(updated);
             ext.outputChannel.appendLog(updated);

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Ingress, RegistryCredentials, Secret, WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerAppsAPIClient, Ingress, RegistryCredentials, Secret } from "@azure/arm-app";
 import { Progress } from "vscode";
 import { AzureWizardExecuteStep, LocationListStep } from "vscode-azureextensionui";
 import { containerAppProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { createWebSiteClient } from "../../utils/azureClients";
+import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullProp } from "../../utils/nonNull";
 import { listCredentialsFromRegistry } from "../deployImage/acr/listCredentialsFromRegistry";
@@ -19,7 +19,7 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
     public priority: number = 250;
 
     public async execute(context: IContainerAppContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        const webClient: WebSiteManagementClient = await createWebSiteClient(context);
+        const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient(context);
         let secrets: Secret[], registries: RegistryCredentials[];
 
         if (context.registry) {
@@ -61,9 +61,9 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
         progress.report({ message: creatingSwa });
         ext.outputChannel.appendLog(creatingSwa);
 
-        context.containerApp = await webClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
+        context.containerApp = await appClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
             location: (await LocationListStep.getLocation(context, containerAppProvider)).name,
-            kubeEnvironmentId: context.kubeEnvironmentId,
+            managedEnvironmentId: context.ManagedEnvironmentId,
             configuration: {
                 ingress,
                 secrets,

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -63,7 +63,7 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
 
         context.containerApp = await appClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
             location: (await LocationListStep.getLocation(context, containerAppProvider)).name,
-            managedEnvironmentId: context.ManagedEnvironmentId,
+            managedEnvironmentId: context.managedEnvironmentId,
             configuration: {
                 ingress,
                 secrets,

--- a/src/commands/createContainerApp/ContainerAppNameStep.ts
+++ b/src/commands/createContainerApp/ContainerAppNameStep.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from '@azure/arm-appservice';
+import { ContainerAppsAPIClient } from "@azure/arm-app";
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
-import { containerAppProvider } from '../../constants';
-import { createWebSiteClient } from '../../utils/azureClients';
+import { createContainerAppsAPIClient } from '../../utils/azureClients';
 import { localize } from "../../utils/localize";
 import { IContainerAppContext } from './IContainerAppContext';
 
@@ -41,10 +40,12 @@ export class ContainerAppNameStep extends AzureWizardPromptStep<IContainerAppCon
         }
 
         // do the API call last
-        const client: WebSiteManagementClient = await createWebSiteClient(context);
-        const availability = await client.checkNameAvailability(name, containerAppProvider);
-        if (!availability.nameAvailable) {
-            return availability.reason;
+        try {
+            const client: ContainerAppsAPIClient = await createContainerAppsAPIClient(context);
+            await client.containerApps.get(name, name);
+            return 'Name exists';
+        } catch (err) {
+            // do nothing
         }
 
 

--- a/src/commands/createContainerApp/ContainerAppNameStep.ts
+++ b/src/commands/createContainerApp/ContainerAppNameStep.ts
@@ -6,6 +6,7 @@
 import { ContainerAppsAPIClient } from "@azure/arm-app";
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
 import { createContainerAppsAPIClient } from '../../utils/azureClients';
+import { getResourceGroupFromId } from "../../utils/azureUtils";
 import { localize } from "../../utils/localize";
 import { IContainerAppContext } from './IContainerAppContext';
 
@@ -42,8 +43,9 @@ export class ContainerAppNameStep extends AzureWizardPromptStep<IContainerAppCon
         // do the API call last
         try {
             const client: ContainerAppsAPIClient = await createContainerAppsAPIClient(context);
-            await client.containerApps.get(name, name);
-            return 'Name exists';
+            const managedEnvironmentRg = getResourceGroupFromId(context.managedEnvironmentId);
+            await client.containerApps.get(managedEnvironmentRg, name);
+            return localize('containerAppExists', 'The container app "{0}" already exists in resource group "{1}". Please enter a unique name.', name, managedEnvironmentRg);
         } catch (err) {
             // do nothing
         }

--- a/src/commands/createContainerApp/IContainerAppContext.ts
+++ b/src/commands/createContainerApp/IContainerAppContext.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp } from '@azure/arm-appservice';
+import { ContainerApp } from '@azure/arm-app';
 import { IResourceGroupWizardContext } from 'vscode-azureextensionui';
 import { IDeployImageContext } from '../deployImage/IDeployImageContext';
 
 export interface IContainerAppContext extends IResourceGroupWizardContext, IDeployImageContext {
-    kubeEnvironmentId?: string;
+    ManagedEnvironmentId?: string;
     newContainerAppName?: string;
 
     enableIngress?: boolean;

--- a/src/commands/createContainerApp/IContainerAppContext.ts
+++ b/src/commands/createContainerApp/IContainerAppContext.ts
@@ -8,7 +8,7 @@ import { IResourceGroupWizardContext } from 'vscode-azureextensionui';
 import { IDeployImageContext } from '../deployImage/IDeployImageContext';
 
 export interface IContainerAppContext extends IResourceGroupWizardContext, IDeployImageContext {
-    ManagedEnvironmentId?: string;
+    managedEnvironmentId: string;
     newContainerAppName?: string;
 
     enableIngress?: boolean;

--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -6,13 +6,13 @@
 import { IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { ContainerAppTreeItem } from "../../tree/ContainerAppTreeItem";
-import { KubeEnvironmentTreeItem } from "../../tree/KubeEnvironmentTreeItem";
+import { ManagedEnvironmentTreeItem } from "../../tree/ManagedEnvironmentTreeItem";
 import { IContainerAppContext } from "./IContainerAppContext";
 import { showContainerAppCreated } from "./showContainerAppCreated";
 
-export async function createContainerApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IContainerAppContext>, node?: KubeEnvironmentTreeItem): Promise<ContainerAppTreeItem> {
+export async function createContainerApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IContainerAppContext>, node?: ManagedEnvironmentTreeItem): Promise<ContainerAppTreeItem> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<KubeEnvironmentTreeItem>(KubeEnvironmentTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<ManagedEnvironmentTreeItem>(ManagedEnvironmentTreeItem.contextValue, context);
     }
 
     const caNode: ContainerAppTreeItem = await node.createChild(context);

--- a/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
+++ b/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KubeEnvironment } from '@azure/arm-appservice';
+import { ManagedEnvironment } from '@azure/arm-app';
 import { Workspace } from '@azure/arm-operationalinsights';
 import { ICreateChildImplContext, IResourceGroupWizardContext } from 'vscode-azureextensionui';
 
-export interface IKubeEnvironmentContext extends IResourceGroupWizardContext, ICreateChildImplContext {
+export interface IManagedEnvironmentContext extends IResourceGroupWizardContext, ICreateChildImplContext {
 
-    newKubeEnvironmentName?: string;
+    newManagedEnvironmentName?: string;
     logAnalyticsWorkspace?: Workspace;
 
     // created when the wizard is done executing
-    kubeEnvironment?: KubeEnvironment;
+    ManagedEnvironment?: ManagedEnvironment;
 }

--- a/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
+++ b/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
@@ -13,5 +13,5 @@ export interface IManagedEnvironmentContext extends IResourceGroupWizardContext,
     logAnalyticsWorkspace?: Workspace;
 
     // created when the wizard is done executing
-    ManagedEnvironment?: ManagedEnvironment;
+    managedEnvironment?: ManagedEnvironment;
 }

--- a/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
+++ b/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
@@ -9,12 +9,12 @@ import { ext } from "../../extensionVariables";
 import { createOperationalInsightsManagementClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullProp, nonNullValue } from "../../utils/nonNull";
-import { IKubeEnvironmentContext } from "./IKubeEnvironmentContext";
+import { IManagedEnvironmentContext } from "./IManagedEnvironmentContext";
 
-export class LogAnalyticsCreateStep extends AzureWizardExecuteStep<IKubeEnvironmentContext> {
+export class LogAnalyticsCreateStep extends AzureWizardExecuteStep<IManagedEnvironmentContext> {
     public priority: number = 200;
 
-    public async execute(context: IKubeEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+    public async execute(context: IManagedEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const opClient = await createOperationalInsightsManagementClient(context);
         const rg = nonNullValue(context.resourceGroup);
 
@@ -22,10 +22,10 @@ export class LogAnalyticsCreateStep extends AzureWizardExecuteStep<IKubeEnvironm
         progress.report({ message: creatingLaw });
         ext.outputChannel.appendLog(creatingLaw);
         context.logAnalyticsWorkspace = await opClient.workspaces.beginCreateOrUpdateAndWait(
-            nonNullProp(rg, 'name'), nonNullProp(context, 'newKubeEnvironmentName'), { location: rg.location });
+            nonNullProp(rg, 'name'), nonNullProp(context, 'newManagedEnvironmentName'), { location: rg.location });
     }
 
-    public shouldExecute(context: IKubeEnvironmentContext): boolean {
+    public shouldExecute(context: IManagedEnvironmentContext): boolean {
         return !context.logAnalyticsWorkspace;
     }
 }

--- a/src/commands/createManagedEnvironment/LogAnalyticsListStep.ts
+++ b/src/commands/createManagedEnvironment/LogAnalyticsListStep.ts
@@ -8,19 +8,19 @@ import { AzureWizardPromptStep, IAzureQuickPickItem, uiUtils } from 'vscode-azur
 import { createOperationalInsightsManagementClient } from '../../utils/azureClients';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
-import { IKubeEnvironmentContext } from './IKubeEnvironmentContext';
+import { IManagedEnvironmentContext } from './IManagedEnvironmentContext';
 
-export class LogAnalyticsListStep extends AzureWizardPromptStep<IKubeEnvironmentContext> {
-    public async prompt(context: IKubeEnvironmentContext): Promise<void> {
+export class LogAnalyticsListStep extends AzureWizardPromptStep<IManagedEnvironmentContext> {
+    public async prompt(context: IManagedEnvironmentContext): Promise<void> {
         const placeHolder: string = localize('selectLogAnalytics', 'Select Log Analytics workspace. Your Log Analytics workspace will contain all your application logs.');
         context.logAnalyticsWorkspace = (await context.ui.showQuickPick(this.getQuickPicks(context), { placeHolder })).data;
     }
 
-    public shouldPrompt(context: IKubeEnvironmentContext): boolean {
+    public shouldPrompt(context: IManagedEnvironmentContext): boolean {
         return !context.logAnalyticsWorkspace;
     }
 
-    private async getQuickPicks(context: IKubeEnvironmentContext): Promise<IAzureQuickPickItem<Workspace | undefined>[]> {
+    private async getQuickPicks(context: IManagedEnvironmentContext): Promise<IAzureQuickPickItem<Workspace | undefined>[]> {
         const picks: IAzureQuickPickItem<Workspace | undefined>[] = [];
 
         picks.push({

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -30,7 +30,7 @@ export class ManagedEnvironmentCreateStep extends AzureWizardExecuteStep<IManage
             getResourceGroupFromId(nonNullProp(logAnalyticsWorkspace, 'id')),
             nonNullProp(logAnalyticsWorkspace, 'name'));
 
-        context.ManagedEnvironment = await client.managedEnvironments.beginCreateOrUpdateAndWait(rgName, nonNullProp(context, 'newManagedEnvironmentName'),
+        context.managedEnvironment = await client.managedEnvironments.beginCreateOrUpdateAndWait(rgName, nonNullProp(context, 'newManagedEnvironmentName'),
             {
                 location: (await LocationListStep.getLocation(context)).name,
                 appLogsConfiguration: {
@@ -45,6 +45,6 @@ export class ManagedEnvironmentCreateStep extends AzureWizardExecuteStep<IManage
     }
 
     public shouldExecute(context: IManagedEnvironmentContext): boolean {
-        return !context.ManagedEnvironment;
+        return !context.managedEnvironment;
     }
 }

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentNameStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentNameStep.ts
@@ -20,7 +20,7 @@ export class ManagedEnvironmentNameStep extends AzureWizardPromptStep<IManagedEn
     }
 
     public shouldPrompt(context: IManagedEnvironmentContext): boolean {
-        return !context.ManagedEnvironment;
+        return !context.managedEnvironment;
     }
 
     private async validateInput(name: string | undefined): Promise<string | undefined> {

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentNameStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentNameStep.ts
@@ -5,22 +5,22 @@
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
 import { localize } from "../../utils/localize";
-import { IKubeEnvironmentContext } from './IKubeEnvironmentContext';
+import { IManagedEnvironmentContext } from './IManagedEnvironmentContext';
 
 let checkNameLength: boolean = false;
-export class KubeEnvironmentNameStep extends AzureWizardPromptStep<IKubeEnvironmentContext> {
-    public async prompt(context: IKubeEnvironmentContext): Promise<void> {
+export class ManagedEnvironmentNameStep extends AzureWizardPromptStep<IManagedEnvironmentContext> {
+    public async prompt(context: IManagedEnvironmentContext): Promise<void> {
         const prompt: string = localize('containerAppNamePrompt', 'Enter a name for the new container app environment.');
-        context.newKubeEnvironmentName = (await context.ui.showInputBox({
+        context.newManagedEnvironmentName = (await context.ui.showInputBox({
             prompt,
             validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateInput(value)
         })).trim();
 
-        context.valuesToMask.push(context.newKubeEnvironmentName);
+        context.valuesToMask.push(context.newManagedEnvironmentName);
     }
 
-    public shouldPrompt(context: IKubeEnvironmentContext): boolean {
-        return !context.kubeEnvironment;
+    public shouldPrompt(context: IManagedEnvironmentContext): boolean {
+        return !context.ManagedEnvironment;
     }
 
     private async validateInput(name: string | undefined): Promise<string | undefined> {

--- a/src/commands/createManagedEnvironment/createManagedEnvironment.ts
+++ b/src/commands/createManagedEnvironment/createManagedEnvironment.ts
@@ -6,17 +6,17 @@
 import { window } from "vscode";
 import { IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
-import { KubeEnvironmentTreeItem } from "../../tree/KubeEnvironmentTreeItem";
+import { ManagedEnvironmentTreeItem } from "../../tree/ManagedEnvironmentTreeItem";
 import { SubscriptionTreeItem } from "../../tree/SubscriptionTreeItem";
 import { localize } from "../../utils/localize";
-import { IKubeEnvironmentContext } from "./IKubeEnvironmentContext";
+import { IManagedEnvironmentContext } from "./IManagedEnvironmentContext";
 
-export async function createKubeEnvironment(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IKubeEnvironmentContext>, node?: SubscriptionTreeItem): Promise<KubeEnvironmentTreeItem> {
+export async function createManagedEnvironment(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IManagedEnvironmentContext>, node?: SubscriptionTreeItem): Promise<ManagedEnvironmentTreeItem> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<SubscriptionTreeItem>(SubscriptionTreeItem.contextValue, context);
     }
 
-    const keNode: KubeEnvironmentTreeItem = await node.createChild(context);
+    const keNode: ManagedEnvironmentTreeItem = await node.createChild(context);
     const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container App environment "{0}".', keNode.name);
     ext.outputChannel.appendLog(createdKuEnv);
     void window.showInformationMessage(createdKuEnv);

--- a/src/commands/deployImage/IDeployImageContext.ts
+++ b/src/commands/deployImage/IDeployImageContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp } from '@azure/arm-appservice';
+import { ContainerApp } from '@azure/arm-app';
 import { ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { ISubscriptionActionContext } from 'vscode-azureextensionui';
 import { SupportedRegistries } from '../../constants';

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerAppsAPIClient } from "@azure/arm-app";
 import { ProgressLocation, window } from "vscode";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, VerifyProvidersStep } from "vscode-azureextensionui";
 import { webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { ContainerAppTreeItem } from "../../tree/ContainerAppTreeItem";
-import { createWebSiteClient } from "../../utils/azureClients";
+import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
 import { getLoginServer } from "../createContainerApp/getLoginServer";
@@ -66,7 +66,7 @@ export async function deployImage(context: IActionContext & Partial<IDeployImage
     await node.runWithTemporaryDescription(context, localize('addingContainer', 'Creating...'), async () => {
         await window.withProgress({ location: ProgressLocation.Notification, title: creatingRevision }, async (): Promise<void> => {
             node = nonNullValue(node);
-            const webClient: WebSiteManagementClient = await createWebSiteClient([wizardContext, node]);
+            const webClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([wizardContext, node]);
 
             ext.outputChannel.appendLog(creatingRevision);
             node.data = await webClient.containerApps.beginCreateOrUpdateAndWait(node.resourceGroupName, node.name, containerAppEnvelope);

--- a/src/commands/ingressCommands.ts
+++ b/src/commands/ingressCommands.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Ingress, WebSiteManagementClient } from '@azure/arm-appservice';
+import { ContainerAppsAPIClient, Ingress } from "@azure/arm-app";
 import { ProgressLocation, window } from 'vscode';
 import { AzureWizard, AzureWizardPromptStep, IActionContext } from 'vscode-azureextensionui';
 import { IngressConstants } from '../constants';
 import { ext } from '../extensionVariables';
 import { IngressDisabledTreeItem, IngressTreeItem } from '../tree/IngressTreeItem';
-import { createWebSiteClient } from '../utils/azureClients';
+import { createContainerAppsAPIClient } from '../utils/azureClients';
 import { localize } from '../utils/localize';
 import { nonNullValueAndProp } from '../utils/nonNull';
 import { EnableIngressStep } from './createContainerApp/EnableIngressStep';
@@ -111,7 +111,7 @@ async function updateIngressSettings(context: IActionContext,
     const containerAppEnvelope = await node.parent.getContainerEnvelopeWithSecrets(context);
     containerAppEnvelope.configuration.ingress = ingress;
 
-    const client: WebSiteManagementClient = await createWebSiteClient([context, node]);
+    const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
     const resourceGroupName = node.parent.resourceGroupName;
     const name = node.parent.name;
 

--- a/src/commands/ingressCommands.ts
+++ b/src/commands/ingressCommands.ts
@@ -29,7 +29,7 @@ export async function toggleIngress(context: IActionContext, node?: IngressTreeI
         const title: string = localize('enableIngress', 'Enable Ingress');
         const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] = [new EnableIngressStep()];
 
-        const wizardContext: IContainerAppContext = { ...context, ...node.subscription };
+        const wizardContext: IContainerAppContext = { ...context, ...node.subscription, managedEnvironmentId: node.parent.managedEnvironmentId };
         const wizard: AzureWizard<IContainerAppContext> = new AzureWizard(wizardContext, {
             title,
             promptSteps,
@@ -69,7 +69,7 @@ export async function editTargetPort(context: IActionContext, node?: IngressTree
     const title: string = localize('updateTargetPort', 'Update Target Port');
     const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] = [new TargetPortStep()];
 
-    const wizardContext: IContainerAppContext = { ...context, ...node.subscription };
+    const wizardContext: IContainerAppContext = { ...context, ...node.subscription, managedEnvironmentId: node.parent.managedEnvironmentId };
     const wizard: AzureWizard<IContainerAppContext> = new AzureWizard(wizardContext, {
         title,
         promptSteps,

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -6,15 +6,15 @@
 import * as ui from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { ContainerAppTreeItem } from '../tree/ContainerAppTreeItem';
-import { KubeEnvironmentTreeItem } from '../tree/KubeEnvironmentTreeItem';
+import { ManagedEnvironmentTreeItem } from '../tree/ManagedEnvironmentTreeItem';
 
 export async function openInPortal(context: ui.IActionContext, node?: ui.AzExtTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<KubeEnvironmentTreeItem>(KubeEnvironmentTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<ManagedEnvironmentTreeItem>(ManagedEnvironmentTreeItem.contextValue, context);
     }
 
     if (node instanceof ContainerAppTreeItem) {
-        // ContainerApp's id don't include the KubeEnvironment (ie the parent) so don't use fullId
+        // ContainerApp's id don't include the ManagedEnvironment (ie the parent) so don't use fullId
         await ui.openInPortal(node, <string>node.data.id);
     } else {
         await ui.openInPortal(node, node.fullId);

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -7,13 +7,13 @@ import { commands } from 'vscode';
 import { AzExtTreeItem, IActionContext, registerCommand, registerErrorHandler, registerReportIssueCommand } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { ContainerAppTreeItem } from '../tree/ContainerAppTreeItem';
-import { KubeEnvironmentTreeItem } from '../tree/KubeEnvironmentTreeItem';
+import { ManagedEnvironmentTreeItem } from '../tree/ManagedEnvironmentTreeItem';
 import { RevisionTreeItem } from '../tree/RevisionTreeItem';
 import { SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
 import { browse } from './browse';
 import { chooseRevisionMode } from './chooseRevisionMode';
 import { createContainerApp } from './createContainerApp/createContainerApp';
-import { createKubeEnvironment } from './createKubeEnvironment/createKubeEnvironment';
+import { createManagedEnvironment } from './createManagedEnvironment/createManagedEnvironment';
 import { deleteNode } from './deleteNode';
 import { deployImage } from './deployImage/deployImage';
 import { editTargetPort, toggleIngress, toggleIngressVisibility } from './ingressCommands';
@@ -29,10 +29,10 @@ export function registerCommands(): void {
     registerCommand('containerApps.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('containerApps.viewProperties', viewProperties);
     registerCommand('containerApps.browse', browse);
-    registerCommand('containerApps.createKubeEnvironment', createKubeEnvironment);
+    registerCommand('containerApps.createManagedEnvironment', createManagedEnvironment);
     registerCommand('containerApps.createContainerApp', createContainerApp);
     registerCommand('containerApps.deployImage', deployImage);
-    registerCommand('containerApps.deleteKubeEnvironment', async (context: IActionContext, node?: KubeEnvironmentTreeItem) => await deleteNode(context, KubeEnvironmentTreeItem.contextValue, node));
+    registerCommand('containerApps.deleteManagedEnvironment', async (context: IActionContext, node?: ManagedEnvironmentTreeItem) => await deleteNode(context, ManagedEnvironmentTreeItem.contextValue, node));
     registerCommand('containerApps.deleteContainerApp', async (context: IActionContext, node?: ContainerAppTreeItem) => await deleteNode(context, ContainerAppTreeItem.contextValue, node));
     registerCommand('containerApps.openLogs', openLogs);
     registerCommand('containerApps.enableIngress', toggleIngress);
@@ -89,12 +89,12 @@ export function registerCommands(): void {
         //     ]
         // };
 
-        // const webClient: WebSiteManagementClient = await createWebSiteClient([context, node]);
+        // const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
         // await webClient.containerApps.beginCreateOrUpdateAndWait(node.resourceGroupName, node.name, containerEnv);
 
         // await webClient.containerApps.beginCreateOrUpdateAndWait(node.resourceGroupName, 'dockercontainer3', {
         //     location: node.data.location,
-        //     kubeEnvironmentId: node.id,
+        //     ManagedEnvironmentId: node.id,
         //     configuration: {
         //         ingress: {
         //             targetPort: 80,

--- a/src/commands/revisionCommands/changeRevisionActiveState.ts
+++ b/src/commands/revisionCommands/changeRevisionActiveState.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerAppsAPIClient } from '@azure/arm-app';
 import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { RevisionTreeItem } from "../../tree/RevisionTreeItem";
-import { createWebSiteClient } from "../../utils/azureClients";
+import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
 
@@ -16,7 +16,7 @@ export async function changeRevisionActiveState(context: IActionContext, command
         node = await ext.tree.showTreeItemPicker<RevisionTreeItem>(RevisionTreeItem.contextValue, context);
     }
 
-    const webClient: WebSiteManagementClient = await createWebSiteClient([context, node]);
+    const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
 
     const temporaryDescriptions = {
         'activate': localize('activating', 'Activating...'),
@@ -27,13 +27,13 @@ export async function changeRevisionActiveState(context: IActionContext, command
         node = nonNullValue(node);
         switch (command) {
             case 'activate':
-                await webClient.containerAppsRevisions.activateRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
+                await appClient.containerAppsRevisions.activateRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
                 break;
             case 'deactivate':
-                await webClient.containerAppsRevisions.deactivateRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
+                await appClient.containerAppsRevisions.deactivateRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
                 break;
             case 'restart':
-                await webClient.containerAppsRevisions.restartRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
+                await appClient.containerAppsRevisions.restartRevision(node.parent.parent.resourceGroupName, node.parent.parent.name, node.name);
                 break;
         }
     });

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -6,13 +6,13 @@
 import { IActionContext, openReadOnlyJson } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { IAzureResourceTreeItem } from '../tree/IAzureResourceTreeItem';
-import { KubeEnvironmentTreeItem } from '../tree/KubeEnvironmentTreeItem';
+import { ManagedEnvironmentTreeItem } from '../tree/ManagedEnvironmentTreeItem';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
 
 export async function viewProperties(context: IActionContext, node?: IAzureResourceTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<KubeEnvironmentTreeItem>(KubeEnvironmentTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<ManagedEnvironmentTreeItem>(ManagedEnvironmentTreeItem.contextValue, context);
     }
 
     if (!node.data) {

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -29,6 +29,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
 
     public name: string;
     public label: string;
+    public managedEnvironmentId: string;
 
     public revisionsTreeItem: RevisionsTreeItem;
 
@@ -41,6 +42,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
 
         this.name = nonNullProp(this.data, 'name');
         this.label = this.name;
+        this.managedEnvironmentId = nonNullProp(this.data, 'managedEnvironmentId');
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, Secret, WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerApp, ContainerAppsAPIClient, Secret } from "@azure/arm-app";
 import { MarkdownString, ProgressLocation, window } from "vscode";
 import { AzExtParentTreeItem, AzExtRequestPrepareOptions, AzExtTreeItem, DialogResponses, IActionContext, parseError, sendRequestWithTimeout, TreeItemIconPath } from "vscode-azureextensionui";
 import { ext } from "../extensionVariables";
-import { createWebSiteClient } from "../utils/azureClients";
+import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { getResourceGroupFromId } from "../utils/azureUtils";
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
@@ -92,7 +92,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
 
         await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
             ext.outputChannel.appendLog(deleting);
-            const webClient: WebSiteManagementClient = await createWebSiteClient([context, this]);
+            const webClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
             try {
                 await webClient.containerApps.beginDeleteAndWait(this.resourceGroupName, this.name);
             } catch (error) {
@@ -110,7 +110,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
     }
 
     public async refreshImpl(context: IActionContext): Promise<void> {
-        const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+        const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         const data = await client.containerApps.get(this.resourceGroupName, this.name);
 
         this.revisionsTreeItem = new RevisionsTreeItem(this);

--- a/src/tree/DaprTreeItem.ts
+++ b/src/tree/DaprTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dapr } from "@azure/arm-appservice";
+import { Dapr } from "@azure/arm-app";
 import { AzExtTreeItem, TreeItemIconPath } from "vscode-azureextensionui";
 import { localize } from "../utils/localize";
 import { treeUtils } from "../utils/treeUtils";

--- a/src/tree/IngressTreeItem.ts
+++ b/src/tree/IngressTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Ingress } from "@azure/arm-appservice";
+import { Ingress } from "@azure/arm-app";
 import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { IngressConstants } from "../constants";

--- a/src/tree/ManagedEnvironmentTreeItem.ts
+++ b/src/tree/ManagedEnvironmentTreeItem.ts
@@ -36,15 +36,17 @@ export class ManagedEnvironmentTreeItem extends AzExtParentTreeItem implements I
         super(parent);
         this.data = ke;
 
-        this.id = nonNullProp(this.data, 'id');
         this.resourceGroupName = getResourceGroupFromId(this.id);
-
         this.name = nonNullProp(this.data, 'name');
         this.label = this.name;
     }
 
     public get iconPath(): TreeItemIconPath {
         return treeUtils.getIconPath('Container App Environments placeholder icon icon');
+    }
+
+    public get id(): string {
+        return nonNullProp(this.data, 'id');
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
@@ -66,7 +68,7 @@ export class ManagedEnvironmentTreeItem extends AzExtParentTreeItem implements I
     }
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
-        const wizardContext: IContainerAppContext = { ...context, ...this.subscription };
+        const wizardContext: IContainerAppContext = { ...context, ...this.subscription, managedEnvironmentId: this.id };
 
         const title: string = localize('createContainerApp', 'Create Container App');
         const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] =
@@ -75,7 +77,6 @@ export class ManagedEnvironmentTreeItem extends AzExtParentTreeItem implements I
 
         wizardContext.newResourceGroupName = this.resourceGroupName;
         await LocationListStep.setLocation(wizardContext, this.data.location);
-        wizardContext.ManagedEnvironmentId = this.id;
 
         const wizard: AzureWizard<IContainerAppContext> = new AzureWizard(wizardContext, {
             title,

--- a/src/tree/ManagedEnvironmentTreeItem.ts
+++ b/src/tree/ManagedEnvironmentTreeItem.ts
@@ -23,7 +23,7 @@ import { ContainerAppTreeItem } from "./ContainerAppTreeItem";
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
 
 export class ManagedEnvironmentTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
-    public static contextValue: string = 'ManagedEnvironment|azResource';
+    public static contextValue: string = 'managedEnvironment|azResource';
     public readonly contextValue: string = ManagedEnvironmentTreeItem.contextValue;
     public readonly data: ManagedEnvironment;
     public resourceGroupName: string;

--- a/src/tree/ManagedEnvironmentTreeItem.ts
+++ b/src/tree/ManagedEnvironmentTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, KubeEnvironment, WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerApp, ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-app";
 import { ProgressLocation, window } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, DialogResponses, IActionContext, ICreateChildImplContext, LocationListStep, parseError, TreeItemIconPath, uiUtils, UserCancelledError, VerifyProvidersStep } from "vscode-azureextensionui";
 import { ContainerAppCreateStep } from "../commands/createContainerApp/ContainerAppCreateStep";
@@ -13,7 +13,7 @@ import { IContainerAppContext } from "../commands/createContainerApp/IContainerA
 import { ContainerRegistryListStep } from "../commands/deployImage/ContainerRegistryListStep";
 import { webProvider } from "../constants";
 import { ext } from "../extensionVariables";
-import { createWebSiteClient } from "../utils/azureClients";
+import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { getResourceGroupFromId } from "../utils/azureUtils";
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
@@ -22,17 +22,17 @@ import { treeUtils } from "../utils/treeUtils";
 import { ContainerAppTreeItem } from "./ContainerAppTreeItem";
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
 
-export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
-    public static contextValue: string = 'kubeEnvironment|azResource';
-    public readonly contextValue: string = KubeEnvironmentTreeItem.contextValue;
-    public readonly data: KubeEnvironment;
+export class ManagedEnvironmentTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
+    public static contextValue: string = 'ManagedEnvironment|azResource';
+    public readonly contextValue: string = ManagedEnvironmentTreeItem.contextValue;
+    public readonly data: ManagedEnvironment;
     public resourceGroupName: string;
     public readonly childTypeLabel: string = localize('containerApp', 'Container App');
 
     public name: string;
     public label: string;
 
-    constructor(parent: AzExtParentTreeItem, ke: KubeEnvironment) {
+    constructor(parent: AzExtParentTreeItem, ke: ManagedEnvironment) {
         super(parent);
         this.data = ke;
 
@@ -48,10 +48,10 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+        const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         // could be more efficient to call this once at Subscription level, and filter based off that but then risk stale data
         const containerApps: ContainerApp[] = (await uiUtils.listAllIterator(client.containerApps.listBySubscription()))
-            .filter(ca => ca.kubeEnvironmentId && ca.kubeEnvironmentId === this.id)
+            .filter(ca => ca.managedEnvironmentId && ca.managedEnvironmentId === this.id)
 
         return await this.createTreeItemsWithErrorHandling(
             containerApps,
@@ -75,7 +75,7 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
 
         wizardContext.newResourceGroupName = this.resourceGroupName;
         await LocationListStep.setLocation(wizardContext, this.data.location);
-        wizardContext.kubeEnvironmentId = this.id;
+        wizardContext.ManagedEnvironmentId = this.id;
 
         const wizard: AzureWizard<IContainerAppContext> = new AzureWizard(wizardContext, {
             title,
@@ -104,12 +104,12 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
             await this.deleteAllContainerApps(context, containerApps);
         }
 
-        const deleting: string = localize('DeletingKubeEnv', 'Deleting Container App environment "{0}"...', this.name);
+        const deleting: string = localize('DeletingManagedEnv', 'Deleting Container App environment "{0}"...', this.name);
         await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
-            const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+            const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
             try {
                 ext.outputChannel.appendLog(deleting);
-                await client.kubeEnvironments.beginDeleteAndWait(this.resourceGroupName, this.name);
+                await client.managedEnvironments.beginDeleteAndWait(this.resourceGroupName, this.name);
             } catch (error) {
                 const pError = parseError(error);
                 // a 204 indicates a success, but sdk is catching it as an exception:
@@ -118,16 +118,16 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
                     throw error;
                 }
             }
-            const deleteSucceeded: string = localize('DeleteKubeEnvSucceeded', 'Successfully deleted container app environment "{0}".', this.name);
+            const deleteSucceeded: string = localize('DeleteManagedEnvSucceeded', 'Successfully deleted container app environment "{0}".', this.name);
             void window.showInformationMessage(deleteSucceeded);
             ext.outputChannel.appendLog(deleteSucceeded);
         });
 
-        async function promptForDelete(node: KubeEnvironmentTreeItem, containerApps: ContainerAppTreeItem[]): Promise<void> {
+        async function promptForDelete(node: ManagedEnvironmentTreeItem, containerApps: ContainerAppTreeItem[]): Promise<void> {
             const numOfResources = containerApps.length;
             const hasNoResources: boolean = !numOfResources;
 
-            const deleteEnv: string = localize('ConfirmDeleteKubeEnv', 'Are you sure you want to delete container app environment "{0}"?', node.name);
+            const deleteEnv: string = localize('ConfirmDeleteManagedEnv', 'Are you sure you want to delete container app environment "{0}"?', node.name);
             const deleteEnvAndApps: string = localize('ConfirmDeleteEnvAndApps', 'Are you sure you want to delete Container App environment "{0}"? Deleting this will delete {1} container app(s) in this environment.',
                 node.name, numOfResources);
 
@@ -149,7 +149,7 @@ export class KubeEnvironmentTreeItem extends AzExtParentTreeItem implements IAzu
                     return isNameEqual(val, node) ? undefined : prompt;
                 }
 
-                function isNameEqual(val: string | undefined, node: KubeEnvironmentTreeItem): boolean {
+                function isNameEqual(val: string | undefined, node: ManagedEnvironmentTreeItem): boolean {
                     return !!val && val.toLowerCase() === node.name.toLowerCase();
                 }
             }

--- a/src/tree/RevisionTreeItem.ts
+++ b/src/tree/RevisionTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KnownRevisionProvisioningState, Revision } from "@azure/arm-appservice";
+import { KnownRevisionProvisioningState, Revision } from "@azure/arm-app";
 import { ThemeColor, ThemeIcon } from "vscode";
 import { AzExtTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { localize } from "../utils/localize";

--- a/src/tree/RevisionsTreeItem.ts
+++ b/src/tree/RevisionsTreeItem.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Revision, WebSiteManagementClient } from "@azure/arm-appservice";
+import { ContainerAppsAPIClient, Revision } from "@azure/arm-app";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, TreeItemIconPath, uiUtils } from "vscode-azureextensionui";
 import { RevisionConstants } from "../constants";
-import { createWebSiteClient } from "../utils/azureClients";
+import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
 import { treeUtils } from "../utils/treeUtils";
 import { ContainerAppTreeItem } from "./ContainerAppTreeItem";
@@ -36,7 +36,7 @@ export class RevisionsTreeItem extends AzExtParentTreeItem {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+        const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         const revisions: Revision[] = await uiUtils.listAllIterator(client.containerAppsRevisions.listRevisions(this.parent.resourceGroupName, this.parent.name));
 
         return await this.createTreeItemsWithErrorHandling(
@@ -52,7 +52,7 @@ export class RevisionsTreeItem extends AzExtParentTreeItem {
     }
 
     public async getRevision(context: IActionContext, name: string): Promise<Revision> {
-        const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+        const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         return await client.containerAppsRevisions.getRevision(this.parent.resourceGroupName, this.parent.name, name);
     }
 }

--- a/src/tree/ScaleRuleGroupTreeItem.ts
+++ b/src/tree/ScaleRuleGroupTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ScaleRule } from "@azure/arm-appservice";
+import { ScaleRule } from "@azure/arm-app";
 import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, TreeItemIconPath } from "vscode-azureextensionui";
 import { localize } from "../utils/localize";

--- a/src/tree/ScaleRuleTreeItem.ts
+++ b/src/tree/ScaleRuleTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ScaleRule } from "@azure/arm-appservice";
+import { ScaleRule } from "@azure/arm-app";
 import { ThemeIcon } from "vscode";
 import { AzExtTreeItem, TreeItemIconPath } from "vscode-azureextensionui";
 import { localize } from "../utils/localize";

--- a/src/tree/ScaleTreeItem.ts
+++ b/src/tree/ScaleTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Scale } from "@azure/arm-appservice";
+import { Scale } from "@azure/arm-app";
 import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, TreeItemIconPath } from "vscode-azureextensionui";
 import { localize } from "../utils/localize";

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from '@azure/arm-appservice';
+import { ContainerAppsAPIClient } from "@azure/arm-app";
 import { ContainerRegistryManagementClient, ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { OperationalInsightsManagementClient } from '@azure/arm-operationalinsights';
 import { ContainerRegistryClient, KnownContainerRegistryAudience } from '@azure/container-registry';
@@ -13,8 +13,8 @@ import { AzExtClientContext, createAzureClient, parseClientContext } from 'vscod
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
-export async function createWebSiteClient(context: AzExtClientContext): Promise<WebSiteManagementClient> {
-    return createAzureClient(context, (await import('@azure/arm-appservice')).WebSiteManagementClient);
+export async function createContainerAppsAPIClient(context: AzExtClientContext): Promise<ContainerAppsAPIClient> {
+    return createAzureClient(context, (await import('@azure/arm-app')).ContainerAppsAPIClient)
 }
 
 export async function createContainerRegistryManagementClient(context: AzExtClientContext): Promise<ContainerRegistryManagementClient> {


### PR DESCRIPTION
This is definitely going to be broken due to the fact that this npm package I'm migrating to isn't published yet.  But since I'll be working with this npm package going forward, I wanted to merge this in now since it'll be a pain to retroactively change everything.