### PR TITLE
Fix ADAL tokens, change UI for single/multiple revisions

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require('./out/src/extension');
+const extension = require('./dist/extension.bundle');
 
 async function activate(ctx) {
-    return await extension.activateInternal(ctx, perfStats, true /* ignoreBundle */);
+    return await extension.activateInternal(ctx, perfStats);
 }
 
 async function deactivate(ctx) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
+                "@azure/arm-app": "^1.0.0-beta.1",
                 "@azure/arm-containerregistry": "^8.1.1",
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
@@ -64,6 +65,28 @@
             }
         },
         "node_modules/@azure/abort-controller/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "node_modules/@azure/arm-app": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-app/-/arm-app-1.0.0-beta.1.tgz",
+            "integrity": "sha512-F4g6ZP91aVwhrSU1lGJxSDQhhibbvR519RlmW6m4i8KD5Ir69JSkDoYDyXwqEV6W9IPAnZMxbJYC5lFXIS/kKw==",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/arm-app/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -420,12 +443,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+            "version": "7.16.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+            "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.15.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -2199,14 +2222,20 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001280",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+            "version": "1.0.30001322",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+            "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                }
+            ]
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
@@ -3208,9 +3237,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.897",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.897.tgz",
-            "integrity": "sha512-nRNZhAZ7hVCe75jrCUG7xLOqHMwloJMj6GEXEzY4OMahRGgwerAo+ls/qbqUwFH+E20eaSncKkQ4W8KP5SOiAg==",
+            "version": "1.4.100",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.100.tgz",
+            "integrity": "sha512-pNrSE2naf8fizl6/Uxq8UbKb8hU9EiYW4OzCYswosXoLV5NTMOUVKECNzDaHiUubsPq/kAckOzZd7zd8S8CHVw==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -11795,6 +11824,27 @@
                 }
             }
         },
+        "@azure/arm-app": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-app/-/arm-app-1.0.0-beta.1.tgz",
+            "integrity": "sha512-F4g6ZP91aVwhrSU1lGJxSDQhhibbvR519RlmW6m4i8KD5Ir69JSkDoYDyXwqEV6W9IPAnZMxbJYC5lFXIS/kKw==",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
+            }
+        },
         "@azure/arm-containerregistry": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-8.1.1.tgz",
@@ -12132,12 +12182,12 @@
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+            "version": "7.16.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+            "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.15.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -13533,9 +13583,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001280",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+            "version": "1.0.30001322",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+            "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
             "dev": true
         },
         "chainsaw": {
@@ -14321,9 +14371,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.897",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.897.tgz",
-            "integrity": "sha512-nRNZhAZ7hVCe75jrCUG7xLOqHMwloJMj6GEXEzY4OMahRGgwerAo+ls/qbqUwFH+E20eaSncKkQ4W8KP5SOiAg==",
+            "version": "1.4.100",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.100.tgz",
+            "integrity": "sha512-pNrSE2naf8fizl6/Uxq8UbKb8hU9EiYW4OzCYswosXoLV5NTMOUVKECNzDaHiUubsPq/kAckOzZd7zd8S8CHVw==",
             "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -215,22 +215,22 @@
                 },
                 {
                     "command": "containerApps.chooseRevisionMode",
-                    "when": "view == containerApps && viewItem =~ /revisions/",
-                    "group": "1@1"
+                    "when": "view == containerApps && viewItem =~ /revisionmode:single|revisions$/",
+                    "group": "2@2"
                 },
                 {
                     "command": "containerApps.activateRevision",
-                    "when": "view == containerApps && viewItem =~ /revision[^s]/",
+                    "when": "view == containerApps && viewItem =~ /revision|/",
                     "group": "1@1"
                 },
                 {
                     "command": "containerApps.deactivateRevision",
-                    "when": "view == containerApps && viewItem =~ /revision[^s]/",
+                    "when": "view == containerApps && viewItem =~ /revision|/",
                     "group": "1@2"
                 },
                 {
                     "command": "containerApps.restartRevision",
-                    "when": "view == containerApps && viewItem =~ /revision[^s]/",
+                    "when": "view == containerApps && viewItem =~ /revision|/",
                     "group": "1@3"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -220,17 +220,17 @@
                 },
                 {
                     "command": "containerApps.activateRevision",
-                    "when": "view == containerApps && viewItem =~ /revision|/",
+                    "when": "view == containerApps && viewItem =~ /revision[^a-z]/",
                     "group": "1@1"
                 },
                 {
                     "command": "containerApps.deactivateRevision",
-                    "when": "view == containerApps && viewItem =~ /revision|/",
+                    "when": "view == containerApps && viewItem =~ /revision[^a-z]/",
                     "group": "1@2"
                 },
                 {
                     "command": "containerApps.restartRevision",
-                    "when": "view == containerApps && viewItem =~ /revision|/",
+                    "when": "view == containerApps && viewItem =~ /revision[^a-z]/",
                     "group": "1@3"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -359,6 +359,7 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
+        "@azure/arm-app": "^1.0.0-beta.1",
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,7 +10,7 @@
     "containerApps.browse": "Browse",
     "containerApps.openInPortal": "Open in Portal",
     "containerApps.createContainerApp": "Create Container App...",
-    "containerApps.deployImage": "Deploy Image to Container App...",
+    "containerApps.deployImage": "Update Image in Container App...",
     "containerApps.deleteContainerApp": "Delete Container App...",
     "containerApps.openLogs": "Open Logs",
     "containerApps.disableIngress": "Disable Ingress for Container App..",

--- a/src/commands/chooseRevisionMode.ts
+++ b/src/commands/chooseRevisionMode.ts
@@ -8,30 +8,35 @@ import { ProgressLocation, window } from "vscode";
 import { IActionContext, IAzureQuickPickItem } from "vscode-azureextensionui";
 import { RevisionConstants } from "../constants";
 import { ext } from "../extensionVariables";
+import { ContainerAppTreeItem } from "../tree/ContainerAppTreeItem";
 import { RevisionsTreeItem } from "../tree/RevisionsTreeItem";
 import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
 import { nonNullValue } from "../utils/nonNull";
 
-export async function chooseRevisionMode(context: IActionContext, node?: RevisionsTreeItem): Promise<void> {
+export async function chooseRevisionMode(context: IActionContext, node?: ContainerAppTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<RevisionsTreeItem>(RevisionsTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<ContainerAppTreeItem>(new RegExp(ContainerAppTreeItem.contextValue), context);
+    }
+
+    if (node instanceof RevisionsTreeItem) {
+        node = node.parent;
     }
 
     const picks: IAzureQuickPickItem<string>[] = [RevisionConstants.single, RevisionConstants.multiple];
     const placeHolder = localize('chooseRevision', 'Choose revision mode');
 
-    const currentModeQp = picks.find(mode => mode.data === node?.parent.data.configuration?.activeRevisionsMode?.toLowerCase());
-    currentModeQp ? currentModeQp.description += localize('current', ' (current)') : undefined;
+    const currentModeQp = picks.find(mode => mode.data === node?.data.configuration?.activeRevisionsMode?.toLowerCase());
+    currentModeQp ? currentModeQp.detail = localize('current', ' current') : undefined;
 
     const result = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
 
     if (currentModeQp !== result) {
         // only update it if it's actually different
         const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
-        const containerAppEnvelope = await node.parent.getContainerEnvelopeWithSecrets(context);
-        const updating = localize('updatingRevision', 'Updating revision mode of "{0}" to "{1}"...', node.parent.name, result.label.toLowerCase());
-        const updated = localize('updatedRevision', 'Updated revision mode of "{0}" to "{1}".', node.parent.name, result.label.toLowerCase());
+        const containerAppEnvelope = await node.getContainerEnvelopeWithSecrets(context);
+        const updating = localize('updatingRevision', 'Updating revision mode of "{0}" to "{1}"...', node.name, result.label.toLowerCase());
+        const updated = localize('updatedRevision', 'Updated revision mode of "{0}" to "{1}".', node.name, result.label.toLowerCase());
 
         containerAppEnvelope.configuration.activeRevisionsMode = result.data;
 
@@ -39,7 +44,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Revisio
         containerAppEnvelope.configuration.ingress.traffic = result.data === 'single' ? undefined : containerAppEnvelope.configuration.ingress.traffic;
 
         await window.withProgress({ location: ProgressLocation.Notification, title: updating }, async (): Promise<void> => {
-            const pNode = nonNullValue(node).parent;
+            const pNode = nonNullValue(node);
             ext.outputChannel.appendLog(updating);
             await appClient.containerApps.beginCreateOrUpdateAndWait(pNode.resourceGroupName, pNode.name, containerAppEnvelope);
 
@@ -48,5 +53,5 @@ export async function chooseRevisionMode(context: IActionContext, node?: Revisio
         });
     }
 
-    await node.parent.refresh(context);
+    await node.refresh(context);
 }

--- a/src/commands/chooseRevisionMode.ts
+++ b/src/commands/chooseRevisionMode.ts
@@ -14,7 +14,7 @@ import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
 import { nonNullValue } from "../utils/nonNull";
 
-export async function chooseRevisionMode(context: IActionContext, node?: ContainerAppTreeItem): Promise<void> {
+export async function chooseRevisionMode(context: IActionContext, node?: ContainerAppTreeItem | RevisionsTreeItem): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<ContainerAppTreeItem>(new RegExp(ContainerAppTreeItem.contextValue), context);
     }
@@ -45,7 +45,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Contain
         containerAppEnvelope.configuration.ingress.traffic = result.data === 'single' ? undefined : containerAppEnvelope.configuration.ingress.traffic;
 
         await window.withProgress({ location: ProgressLocation.Notification, title: updating }, async (): Promise<void> => {
-            const pNode = nonNullValue(node);
+            const pNode = nonNullValue(node) as ContainerAppTreeItem;
             ext.outputChannel.appendLog(updating);
             await appClient.containerApps.beginCreateOrUpdateAndWait(pNode.resourceGroupName, pNode.name, containerAppEnvelope);
 

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -3,30 +3,33 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from "@azure/arm-app";
+import { ContainerApp, ContainerAppsAPIClient } from "@azure/arm-app";
 import { ProgressLocation, window } from "vscode";
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, VerifyProvidersStep } from "vscode-azureextensionui";
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, ITreeItemPickerContext, VerifyProvidersStep } from "vscode-azureextensionui";
 import { webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { ContainerAppTreeItem } from "../../tree/ContainerAppTreeItem";
 import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
+import { EnvironmentVariablesListStep } from "../createContainerApp/EnvironmentVariablesListStep";
 import { getLoginServer } from "../createContainerApp/getLoginServer";
 import { listCredentialsFromRegistry } from "./acr/listCredentialsFromRegistry";
 import { ContainerRegistryListStep } from "./ContainerRegistryListStep";
 import { IDeployImageContext } from "./IDeployImageContext";
 
-export async function deployImage(context: IActionContext & Partial<IDeployImageContext>, node?: ContainerAppTreeItem): Promise<void> {
+export async function deployImage(context: ITreeItemPickerContext & Partial<IDeployImageContext>, node?: ContainerAppTreeItem): Promise<void> {
+
     if (!node) {
+        context.suppressCreatePick = true;
         node = await ext.tree.showTreeItemPicker<ContainerAppTreeItem>(ContainerAppTreeItem.contextValue, context);
     }
 
     const wizardContext: IDeployImageContext = { ...context, ...node.subscription, targetContainer: node.data };
 
-    const title: string = localize('deployImage', 'Deploy image to "{0}"', node.name);
+    const title: string = localize('updateImage', 'Update image in "{0}"', node.name);
     const promptSteps: AzureWizardPromptStep<IDeployImageContext>[] =
-        [new ContainerRegistryListStep()];
+        [new ContainerRegistryListStep(), new EnvironmentVariablesListStep()];
     const executeSteps: AzureWizardExecuteStep<IDeployImageContext>[] = [new VerifyProvidersStep([webProvider])];
 
     const wizard: AzureWizard<IDeployImageContext> = new AzureWizard(wizardContext, {
@@ -39,30 +42,35 @@ export async function deployImage(context: IActionContext & Partial<IDeployImage
     await wizard.prompt();
     await wizard.execute();
 
-    const containerAppEnvelope = await node.getContainerEnvelopeWithSecrets(context);
+    const containerAppEnvelope = <ContainerApp>JSON.parse(JSON.stringify(node.data));
 
-    // if this loginServer doesn't exist, then we need to add new credentials
-    if (context.registry) {
-        const registry = context.registry;
-        if (!containerAppEnvelope.configuration.registries?.some(r => r.server === registry.loginServer)) {
-            const { username, password } = await listCredentialsFromRegistry(wizardContext, registry);
-            containerAppEnvelope.configuration?.registries?.push(
-                {
-                    server: registry.loginServer,
-                    username: username,
-                    passwordSecretRef: password.name
-                }
-            )
-            containerAppEnvelope.configuration?.secrets?.push({ name: password.name, value: password.value });
-        }
+    containerAppEnvelope.configuration ||= {};
+    // we need to remove stale secrets and registries if they exist
+    containerAppEnvelope.configuration.secrets = []
+    containerAppEnvelope.configuration.registries = [];
+
+    // for ACR
+    if (wizardContext.registry) {
+        const registry = wizardContext.registry;
+        const { username, password } = await listCredentialsFromRegistry(wizardContext, registry);
+        containerAppEnvelope.configuration.registries.push(
+            {
+                server: registry.loginServer,
+                username: username,
+                passwordSecretRef: password.name
+            }
+        )
+        containerAppEnvelope.configuration.secrets.push({ name: password.name, value: password.value });
     }
-    containerAppEnvelope.template.containers ||= [];
+
+    // we want to replace the old image
+    containerAppEnvelope.template ||= {};
+    containerAppEnvelope.template.containers = [];
     containerAppEnvelope.template.containers.push(
         { image: `${getLoginServer(wizardContext)}/${wizardContext.repositoryName}:${wizardContext.tag}`, name: `${wizardContext.repositoryName}-${wizardContext.tag}` }
     )
 
     const creatingRevision = localize('creatingRevision', 'Creating a new revision for container app "{0}"...', node.name);
-
     await node.runWithTemporaryDescription(context, localize('addingContainer', 'Creating...'), async () => {
         await window.withProgress({ location: ProgressLocation.Notification, title: creatingRevision }, async (): Promise<void> => {
             node = nonNullValue(node);

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, ContainerAppsAPIClient, Secret } from "@azure/arm-app";
+import { ContainerApp, ContainerAppsAPIClient, ContainerAppSecret } from "@azure/arm-app";
 import { MarkdownString, ProgressLocation, window } from "vscode";
-import { AzExtParentTreeItem, AzExtRequestPrepareOptions, AzExtTreeItem, DialogResponses, IActionContext, parseError, sendRequestWithTimeout, TreeItemIconPath } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
+import { RevisionConstants } from "../constants";
 import { ext } from "../extensionVariables";
 import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { getResourceGroupFromId } from "../utils/azureUtils";
@@ -13,7 +14,6 @@ import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
 import { openUrl } from "../utils/openUrl";
 import { treeUtils } from "../utils/treeUtils";
-import { DaprTreeItem } from "./DaprTreeItem";
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
 import { IngressDisabledTreeItem, IngressTreeItem } from "./IngressTreeItem";
 import { LogsTreeItem } from "./LogsTreeItem";
@@ -23,7 +23,7 @@ import { ScaleTreeItem } from "./ScaleTreeItem";
 
 export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
     public static contextValue: string = 'containerApp|azResource';
-    public readonly contextValue: string = ContainerAppTreeItem.contextValue;
+    public contextValue: string;
     public data: ContainerApp;
     public resourceGroupName: string;
 
@@ -43,6 +43,8 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
         this.name = nonNullProp(this.data, 'name');
         this.label = this.name;
         this.managedEnvironmentId = nonNullProp(this.data, 'managedEnvironmentId');
+
+        this.contextValue = `${ContainerAppTreeItem.contextValue}|revisionmode:${this.getRevisionMode()}`;
     }
 
     public get iconPath(): TreeItemIconPath {
@@ -54,9 +56,12 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
-        this.revisionsTreeItem = new RevisionsTreeItem(this);
+        const children: AzExtTreeItem[] = [/* new DaprTreeItem(this, this.data.template?.dapr) */];
+        if (this.getRevisionMode() === 'multiple') {
+            this.revisionsTreeItem = new RevisionsTreeItem(this);
+            children.push(this.revisionsTreeItem);
+        }
 
-        const children: AzExtTreeItem[] = [this.revisionsTreeItem, new DaprTreeItem(this, this.data.template?.dapr)];
         this.data.configuration?.ingress ? children.push(new IngressTreeItem(this, this.data.configuration?.ingress)) : children.push(new IngressDisabledTreeItem(this));
         children.push(new ScaleTreeItem(this, this.data.template?.scale), new LogsTreeItem(this))
         return children;
@@ -115,7 +120,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
         const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         const data = await client.containerApps.get(this.resourceGroupName, this.name);
 
-        this.revisionsTreeItem = new RevisionsTreeItem(this);
+        this.contextValue = `${ContainerAppTreeItem.contextValue}|revisionMode${this.getRevisionMode()}`;
         this.data = data;
     }
 
@@ -143,16 +148,26 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
         }
 
         const concreteContainerAppEnvelope = <Concrete<ContainerApp>>containerAppEnvelope;
-        const options: AzExtRequestPrepareOptions = {
-            method: 'POST',
-            queryParameters: { 'api-version': '2021-03-01' },
-            pathTemplate: `${this.id}/listSecrets`,
-        };
 
-        const response = await sendRequestWithTimeout(context, options, 5000, this.subscription.credentials);
-        // if 204, needs to be an empty []
-        concreteContainerAppEnvelope.configuration.secrets = response.status === 204 ? [] : <Secret[]>response.parsedBody;
+        // bug that returns 204 if there are no secrets
+        let secrets: ContainerAppSecret[] = [];
+        try {
+            const webClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
+            secrets = ((await webClient.containerApps.listSecrets(this.resourceGroupName, this.name)).value);
+        } catch (error) {
+            const pError = parseError(error);
+            if (pError.errorType !== '204') {
+                throw error;
+            }
+        }
+
+        concreteContainerAppEnvelope.configuration.secrets = secrets;
         return concreteContainerAppEnvelope;
+    }
+
+    public getRevisionMode(): string {
+        return this.data.configuration?.activeRevisionsMode?.toLowerCase() === 'single' ?
+            RevisionConstants.single.data : RevisionConstants.multiple.data;
     }
 
     public async resolveTooltip(): Promise<MarkdownString> {

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -120,7 +120,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
         const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);
         const data = await client.containerApps.get(this.resourceGroupName, this.name);
 
-        this.contextValue = `${ContainerAppTreeItem.contextValue}|revisionMode${this.getRevisionMode()}`;
+        this.contextValue = `${ContainerAppTreeItem.contextValue}|revisionmode:${this.getRevisionMode()}`;
         this.data = data;
     }
 

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -6,6 +6,7 @@
 import { ContainerApp, ContainerAppsAPIClient, ContainerAppSecret } from "@azure/arm-app";
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, parseError, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { MarkdownString, ProgressLocation, window } from "vscode";
+import { RevisionConstants } from "../constants";
 import { ext } from "../extensionVariables";
 import { createContainerAppsAPIClient } from "../utils/azureClients";
 import { getResourceGroupFromId } from "../utils/azureUtils";

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -149,7 +149,8 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
 
         const concreteContainerAppEnvelope = <Concrete<ContainerApp>>containerAppEnvelope;
 
-        // bug that returns 204 if there are no secrets
+        // https://github.com/Azure/azure-sdk-for-js/issues/21101
+        // a 204 indicates no secrets, but sdk is catching it as an exception
         let secrets: ContainerAppSecret[] = [];
         try {
             const webClient: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, this]);

--- a/src/tree/DaprTreeItem.ts
+++ b/src/tree/DaprTreeItem.ts
@@ -22,7 +22,7 @@ export class DaprTreeItem extends AzExtTreeItem implements IAzureResourceTreeIte
         super(parent);
         this.label = localize('dapr', 'Dapr');
         this.data = data || {};
-        this.description = this.parent.data.template?.dapr ? 'Enabled' : 'Disabled';
+        // this.description = this.parent.data.template?.dapr ? 'Enabled' : 'Disabled';
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -23,6 +23,11 @@ export async function createContainerRegistryManagementClient(context: AzExtClie
 
 export function createContainerRegistryClient(context: AzExtClientContext, registry: ContainerRegistryManagementModels.Registry): ContainerRegistryClient {
     const clientContext = parseClientContext(context);
+    // @azure/container-registry doesn't support ADAL tokens at all.  If it sees `signRequest` is defined
+    // it errors, but we don't actually need `signRequest` because this is a T2 package
+    const credential = clientContext.credentials as { signRequest: unknown };
+    credential.signRequest = undefined;
+
     return new ContainerRegistryClient(`https://${registry.loginServer}`, clientContext.credentials,
         { audience: KnownContainerRegistryAudience.AzureResourceManagerPublicCloud });
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/47

If the Container App is in single revision mode, the revision tree item shouldn't be displayed because it's just confusing.  Based on whether or not it's enabled, where the user can swap RevisionMode context action exists on different tree items (which seems like it could be potentially confusing).

The wonky stuff I'm doing with the credentials... Basically, the T2 package for registry will ignore the credentials and options that I pass it if `signRequest` is defined.  Since that command is only for backwards compatibility, the easiest way to fix this is to just make it undefined when we need to use it.   Since `parseContext` returns a new object, messing with credentials shouldn't delete `signRequest` everywhere.

