### PR TITLE
Browse after revision update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@azure/arm-containerregistry": "^8.1.1",
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
-                "@azure/container-registry": "^1.0.0",
+                "@azure/container-registry": "1.0.0-beta.5",
                 "@azure/loganalytics": "^0.3.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "@microsoft/vscode-azext-azureutils": "^0.1.3",
@@ -203,9 +203,9 @@
             }
         },
         "node_modules/@azure/container-registry": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0.tgz",
-            "integrity": "sha512-yOOhHvCXpKlkVSJHsisg4N9vkZ4RAMm4gd5HJEksAffhdLWVWRtRGQaRT7oylMIlTZgyJZCuflHmsmU5E/2OSw==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.5.tgz",
+            "integrity": "sha512-i6paEU7PX4L3CwVe5CD+IWtoj1H6SHvi6c71WKZqrbHsZJ36q3o1xlIOekrYU1ZJwaswlWf03j3u1rlGtHjbAA==",
             "dependencies": {
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-client": "^1.0.0",
@@ -11972,9 +11972,9 @@
             }
         },
         "@azure/container-registry": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0.tgz",
-            "integrity": "sha512-yOOhHvCXpKlkVSJHsisg4N9vkZ4RAMm4gd5HJEksAffhdLWVWRtRGQaRT7oylMIlTZgyJZCuflHmsmU5E/2OSw==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.0.0-beta.5.tgz",
+            "integrity": "sha512-i6paEU7PX4L3CwVe5CD+IWtoj1H6SHvi6c71WKZqrbHsZJ36q3o1xlIOekrYU1ZJwaswlWf03j3u1rlGtHjbAA==",
             "requires": {
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-client": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",
-        "@azure/container-registry": "^1.0.0",
+        "@azure/container-registry": "1.0.0-beta.5",
         "@azure/loganalytics": "^0.3.0",
         "@azure/ms-rest-js": "^2.2.1",
         "@microsoft/vscode-azext-azureutils": "^0.1.3",

--- a/src/commands/createContainerApp/showContainerAppCreated.ts
+++ b/src/commands/createContainerApp/showContainerAppCreated.ts
@@ -9,16 +9,20 @@ import { ext } from "../../extensionVariables";
 import { ContainerAppTreeItem } from "../../tree/ContainerAppTreeItem";
 import { localize } from "../../utils/localize";
 
-export async function showContainerAppCreated(caNode: ContainerAppTreeItem): Promise<void> {
+export async function showContainerAppCreated(node: ContainerAppTreeItem, isUpdate: boolean = false): Promise<void> {
     return await callWithTelemetryAndErrorHandling('containerApps.showCaCreated', async (context: IActionContext) => {
-        const createdCa: string = localize('createdCa', 'Successfully created new container app "{0}".', caNode.name);
-        ext.outputChannel.appendLog(createdCa);
+        const createdCa: string = localize('createdCa', 'Successfully created new container app "{0}".', node.name);
+        const createdRevision = localize('createdRevision', 'Created a new revision "{1}" for container app "{0}"', node.name, node.data.latestRevisionName);
+        const message = isUpdate ? createdRevision : createdCa;
+        ext.outputChannel.appendLog(message);
 
         const browse: MessageItem = { title: localize('browse', 'Browse') };
-        await window.showInformationMessage(createdCa, browse).then(async (result) => {
+        const buttons: MessageItem[] = [];
+        if (node.ingressEnabled()) { buttons.push(browse) }
+        await window.showInformationMessage(message, ...buttons).then(async (result) => {
             context.telemetry.properties.clicked = 'canceled';
             if (result === browse) {
-                await caNode.browse();
+                await node.browse();
                 context.telemetry.properties.clicked = 'browse';
             }
         });

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -15,6 +15,7 @@ import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
 import { EnvironmentVariablesListStep } from "../createContainerApp/EnvironmentVariablesListStep";
 import { getLoginServer } from "../createContainerApp/getLoginServer";
+import { showContainerAppCreated } from "../createContainerApp/showContainerAppCreated";
 import { listCredentialsFromRegistry } from "./acr/listCredentialsFromRegistry";
 import { ContainerRegistryListStep } from "./ContainerRegistryListStep";
 import { IDeployImageContext } from "./IDeployImageContext";
@@ -80,9 +81,7 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
             ext.outputChannel.appendLog(creatingRevision);
             node.data = await webClient.containerApps.beginCreateOrUpdateAndWait(node.resourceGroupName, node.name, containerAppEnvelope);
 
-            const createdRevision = localize('createdRevision', 'Created a new revision "{1}" for container app "{0}"', node.name, node.data.latestRevisionName);
-            void window.showInformationMessage(createdRevision);
-            ext.outputChannel.appendLog(createdRevision);
+            void showContainerAppCreated(node, true);
         });
     });
 

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -63,7 +63,7 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
             children.push(this.revisionsTreeItem);
         }
 
-        this.data.configuration?.ingress ? children.push(new IngressTreeItem(this, this.data.configuration?.ingress)) : children.push(new IngressDisabledTreeItem(this));
+        this.ingressEnabled() ? children.push(new IngressTreeItem(this, this.data.configuration?.ingress)) : children.push(new IngressDisabledTreeItem(this));
         children.push(new ScaleTreeItem(this, this.data.template?.scale), new LogsTreeItem(this))
         return children;
     }
@@ -78,11 +78,11 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
 
     public async browse(): Promise<void> {
         // make sure that ingress is enabled
-        if (!this.data.latestRevisionFqdn) {
+        if (this.ingressEnabled()) {
             throw new Error(localize('enableIngress', 'Enable ingress to perform this action.'));
         }
 
-        await openUrl(`https://${this.data.latestRevisionFqdn}`);
+        await openUrl(`https://${this.data.configuration?.ingress?.fqdn}`);
     }
 
     public async deleteTreeItem(context: IActionContext, skipConfirmation: boolean = false): Promise<void> {
@@ -170,6 +170,10 @@ export class ContainerAppTreeItem extends AzExtParentTreeItem implements IAzureR
     public getRevisionMode(): string {
         return this.data.configuration?.activeRevisionsMode?.toLowerCase() === 'single' ?
             RevisionConstants.single.data : RevisionConstants.multiple.data;
+    }
+
+    public ingressEnabled(): boolean {
+        return !!this.data.configuration?.ingress;
     }
 
     public async resolveTooltip(): Promise<MarkdownString> {


### PR DESCRIPTION
Also marked the "@azure/container-registry": "1.0.0-beta.5" package.  There's a change in 1.0.0 that causes ADAL tokens to not work again.  This is a temporary fix and I'll file an issue against the sdk