### PR TITLE
Correctly parse container image name and fix name regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurecontainerapps",
-    "version": "0.1.1-alpha.6",
+    "version": "0.1.1-alpha.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurecontainerapps",
-            "version": "0.1.1-alpha.6",
+            "version": "0.1.1-alpha.7",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-app": "^1.0.0-alpha.20220330.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurecontainerapps",
     "displayName": "Azure Container Apps",
     "description": "%containerApps.description%",
-    "version": "0.1.1-alpha.6",
+    "version": "0.1.1-alpha.7",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-containerapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -64,7 +64,7 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
         ext.outputChannel.appendLog(creatingSwa);
 
         context.image ||= `${getLoginServer(context)}/${context.repositoryName}:${context.tag}`;
-        const name = context.image.substring(context.image.lastIndexOf('/') + 1).replace(':', '-');
+        const name = context.image.substring(context.image.lastIndexOf('/') + 1).replace(/[^0-9a-zA-Z-]/g, '-');
 
         context.containerApp = await appClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
             location: (await LocationListStep.getLocation(context, containerAppProvider)).name,

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -13,6 +13,7 @@ import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { nonNullProp } from "../../utils/nonNull";
 import { listCredentialsFromRegistry } from "../deployImage/acr/listCredentialsFromRegistry";
+import { getContainerNameForImage } from "../deployImage/getContainerNameForImage";
 import { getLoginServer } from "./getLoginServer";
 import { IContainerAppContext } from "./IContainerAppContext";
 
@@ -64,7 +65,7 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
         ext.outputChannel.appendLog(creatingSwa);
 
         context.image ||= `${getLoginServer(context)}/${context.repositoryName}:${context.tag}`;
-        const name = context.image.substring(context.image.lastIndexOf('/') + 1).replace(/[^0-9a-zA-Z-]/g, '-');
+        const name = getContainerNameForImage(context.image);
 
         context.containerApp = await appClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
             location: (await LocationListStep.getLocation(context, containerAppProvider)).name,

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -18,6 +18,7 @@ import { getLoginServer } from "../createContainerApp/getLoginServer";
 import { showContainerAppCreated } from "../createContainerApp/showContainerAppCreated";
 import { listCredentialsFromRegistry } from "./acr/listCredentialsFromRegistry";
 import { ContainerRegistryListStep } from "./ContainerRegistryListStep";
+import { getContainerNameForImage } from "./getContainerNameForImage";
 import { IDeployImageContext } from "./IDeployImageContext";
 
 export async function deployImage(context: ITreeItemPickerContext & Partial<IDeployImageContext>, node?: ContainerAppTreeItem): Promise<void> {
@@ -79,7 +80,7 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
     containerAppEnvelope.template.containers = [];
 
     wizardContext.image ||= `${getLoginServer(wizardContext)}/${wizardContext.repositoryName}:${wizardContext.tag}`;
-    const name = wizardContext.image.substring(wizardContext.image.lastIndexOf('/') + 1).replace(/[^0-9a-zA-Z-]/g, '-');
+    const name = getContainerNameForImage(wizardContext.image);
 
     containerAppEnvelope.template.containers.push(
         {

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -77,11 +77,13 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
     // we want to replace the old image
     containerAppEnvelope.template ||= {};
     containerAppEnvelope.template.containers = [];
+
+    wizardContext.image ||= `${getLoginServer(wizardContext)}/${wizardContext.repositoryName}:${wizardContext.tag}`;
+    const name = wizardContext.image.substring(wizardContext.image.lastIndexOf('/') + 1).replace(/[^0-9a-zA-Z-]/g, '-');
+
     containerAppEnvelope.template.containers.push(
         {
-            image: `${getLoginServer(wizardContext)}/${wizardContext.repositoryName}:${wizardContext.tag}`,
-            name: `${wizardContext.repositoryName}-${wizardContext.tag}`,
-            env: wizardContext.environmentVariables
+            image: wizardContext.image, name, env: wizardContext.environmentVariables
         }
     )
 

--- a/src/commands/deployImage/getContainerNameForImage.ts
+++ b/src/commands/deployImage/getContainerNameForImage.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function getContainerNameForImage(containerImageName: string): string {
+    return containerImageName.substring(containerImageName.lastIndexOf('/') + 1).replace(/[^0-9a-zA-Z-]/g, '-');
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/122
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/19

`.` are common in tags, but not allowed for container app names.  Since this is automatically generated, it was blocking people from creating with certain tags.