### PR TITLE
Update SDK and remove use of getting secrets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurecontainerapps",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurecontainerapps",
-            "version": "0.1.1",
+            "version": "0.1.2-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appcontainers": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@azure/arm-app": "^1.0.0-alpha.20220330.1",
+                "@azure/arm-appcontainers": "^1.0.0",
                 "@azure/arm-containerregistry": "^8.1.1",
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
@@ -70,27 +70,27 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
-        "node_modules/@azure/arm-app": {
-            "version": "1.0.0-alpha.20220330.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-app/-/arm-app-1.0.0-alpha.20220330.1.tgz",
-            "integrity": "sha512-nS1d2GEykDiydIgg9HStYkeQ6ukbcdj+N3OLReTa4JKa7lcQRazgr6c23nymjkDoECAbQ83Ki97YzhEFfK8/XQ==",
+        "node_modules/@azure/arm-appcontainers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-1.0.0.tgz",
+            "integrity": "sha512-tzNO0KmqpSNH0M/UReI9KOZn9O391ty5HVNzCew2H+Nn9ofI1mbnG9drOQvycgBUS9UjPBiTEiwJpEtjtIpG4w==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
+                "@azure/core-client": "^1.5.0",
                 "@azure/core-lro": "^2.2.0",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/arm-app/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        "node_modules/@azure/arm-appcontainers/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@azure/arm-containerregistry": {
             "version": "8.1.1",
@@ -247,15 +247,27 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/core-client": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.2.tgz",
-            "integrity": "sha512-qfkRYKmeEmisluMdGTbBtXeyBLaImjFeVW0gcT5yRAwxJmlnTvSyD+a3PjukAtjIrl/tnb4WSJOBpONSJ91+5Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.0.tgz",
+            "integrity": "sha512-YhSf4cb61ApSjItscp9XoaLq8KRnacPDAhmjAZSMnn/gs6FhFbZNfOBOErG2dDj7JRknVtCmJ5mLmfR2sLa11A==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-asynciterator-polyfill": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.4.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-rest-pipeline": "^1.5.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.0.0",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/core-client/node_modules/@azure/core-tracing": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+            "dependencies": {
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -304,19 +316,31 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.2.tgz",
-            "integrity": "sha512-kymICKESeHBpVLgQiAxllgWdSTopkqtmfPac8ITwMCxNEC6hzbSpqApYbjzxbBNkBMgoD4GESo6LLhR/sPh6kA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
+            "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-tracing": "^1.0.1",
+                "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
                 "tslib": "^2.2.0",
                 "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+            "dependencies": {
+                "tslib": "^2.2.0"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -343,6 +367,22 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "node_modules/@azure/core-util": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0.tgz",
+            "integrity": "sha512-yWshY9cdPthlebnb3Zuz/j0Lv4kjU6u7PR5sW7A9FF7EX+0irMRJAtyTq5TPiDHJfjH8gTSlnIYFj9m7Ed76IQ==",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/core-util/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@azure/loganalytics": {
             "version": "0.3.0",
@@ -11842,24 +11882,24 @@
                 }
             }
         },
-        "@azure/arm-app": {
-            "version": "1.0.0-alpha.20220330.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-app/-/arm-app-1.0.0-alpha.20220330.1.tgz",
-            "integrity": "sha512-nS1d2GEykDiydIgg9HStYkeQ6ukbcdj+N3OLReTa4JKa7lcQRazgr6c23nymjkDoECAbQ83Ki97YzhEFfK8/XQ==",
+        "@azure/arm-appcontainers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-1.0.0.tgz",
+            "integrity": "sha512-tzNO0KmqpSNH0M/UReI9KOZn9O391ty5HVNzCew2H+Nn9ofI1mbnG9drOQvycgBUS9UjPBiTEiwJpEtjtIpG4w==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
+                "@azure/core-client": "^1.5.0",
                 "@azure/core-lro": "^2.2.0",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
                 }
             }
         },
@@ -12014,18 +12054,27 @@
             }
         },
         "@azure/core-client": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.2.tgz",
-            "integrity": "sha512-qfkRYKmeEmisluMdGTbBtXeyBLaImjFeVW0gcT5yRAwxJmlnTvSyD+a3PjukAtjIrl/tnb4WSJOBpONSJ91+5Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.0.tgz",
+            "integrity": "sha512-YhSf4cb61ApSjItscp9XoaLq8KRnacPDAhmjAZSMnn/gs6FhFbZNfOBOErG2dDj7JRknVtCmJ5mLmfR2sLa11A==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-asynciterator-polyfill": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.4.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-rest-pipeline": "^1.5.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.0.0",
+                "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "dependencies": {
+                "@azure/core-tracing": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+                    "requires": {
+                        "tslib": "^2.2.0"
+                    }
+                },
                 "tslib": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -12068,13 +12117,14 @@
             }
         },
         "@azure/core-rest-pipeline": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.3.2.tgz",
-            "integrity": "sha512-kymICKESeHBpVLgQiAxllgWdSTopkqtmfPac8ITwMCxNEC6hzbSpqApYbjzxbBNkBMgoD4GESo6LLhR/sPh6kA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
+            "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-tracing": "^1.0.1",
+                "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
                 "http-proxy-agent": "^4.0.1",
@@ -12083,6 +12133,14 @@
                 "uuid": "^8.3.0"
             },
             "dependencies": {
+                "@azure/core-tracing": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+                    "requires": {
+                        "tslib": "^2.2.0"
+                    }
+                },
                 "tslib": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -12103,6 +12161,21 @@
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
                     "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
+            }
+        },
+        "@azure/core-util": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0.tgz",
+            "integrity": "sha512-yWshY9cdPthlebnb3Zuz/j0Lv4kjU6u7PR5sW7A9FF7EX+0irMRJAtyTq5TPiDHJfjH8gTSlnIYFj9m7Ed76IQ==",
+            "requires": {
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurecontainerapps",
     "displayName": "Azure Container Apps",
     "description": "%containerApps.description%",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-containerapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -382,7 +382,7 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@azure/arm-app": "^1.0.0-alpha.20220330.1",
+        "@azure/arm-appcontainers": "^1.0.0",
         "@azure/arm-containerregistry": "^8.1.1",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient, Ingress, RegistryCredentials, Secret } from "@azure/arm-app";
+import { ContainerAppsAPIClient, Ingress, RegistryCredentials, Secret } from "@azure/arm-appcontainers";
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress } from "vscode";

--- a/src/commands/createContainerApp/ContainerAppNameStep.ts
+++ b/src/commands/createContainerApp/ContainerAppNameStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from "@azure/arm-app";
+import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { AzureWizardPromptStep } from "@microsoft/vscode-azext-utils";
 import { createContainerAppsAPIClient } from '../../utils/azureClients';
 import { getResourceGroupFromId } from "../../utils/azureUtils";

--- a/src/commands/createContainerApp/IContainerAppContext.ts
+++ b/src/commands/createContainerApp/IContainerAppContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp } from '@azure/arm-app';
+import { ContainerApp } from "@azure/arm-appcontainers";
 import { IResourceGroupWizardContext } from '@microsoft/vscode-azext-azureutils';
 import { IDeployImageContext } from '../deployImage/IDeployImageContext';
 

--- a/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
+++ b/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ManagedEnvironment } from '@azure/arm-app';
+import { ManagedEnvironment } from "@azure/arm-appcontainers";
 import { Workspace } from '@azure/arm-operationalinsights';
 import { IResourceGroupWizardContext } from '@microsoft/vscode-azext-azureutils';
 import { ICreateChildImplContext } from '@microsoft/vscode-azext-utils';

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from "@azure/arm-app";
+import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress, window } from "vscode";

--- a/src/commands/deployImage/IDeployImageContext.ts
+++ b/src/commands/deployImage/IDeployImageContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, EnvironmentVar } from '@azure/arm-app';
+import { ContainerApp, EnvironmentVar } from "@azure/arm-appcontainers";
 import { ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { ISubscriptionActionContext } from '@microsoft/vscode-azext-utils';
 import { SupportedRegistries } from '../../constants';

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from "@azure/arm-app";
+import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { VerifyProvidersStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, ITreeItemPickerContext } from "@microsoft/vscode-azext-utils";
 import { MessageItem, ProgressLocation, window } from "vscode";

--- a/src/commands/revisionCommands/changeRevisionActiveState.ts
+++ b/src/commands/revisionCommands/changeRevisionActiveState.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from '@azure/arm-app';
+import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
 import { ContainerAppTreeItem } from '../../tree/ContainerAppTreeItem';

--- a/src/commands/updateContainerApp.ts
+++ b/src/commands/updateContainerApp.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ContainerApp, ContainerAppsAPIClient } from "@azure/arm-appcontainers";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { ContainerAppTreeItem } from "../tree/ContainerAppTreeItem";
+import { createContainerAppsAPIClient } from "../utils/azureClients";
+
+export async function updateContainerApp(context: IActionContext, node: ContainerAppTreeItem, updatedSetting: Omit<ContainerApp, 'location'>): Promise<void> {
+    const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, node]);
+    const resourceGroupName = node.resourceGroupName;
+    const name = node.name;
+    const updatedApp: ContainerApp = { ...updatedSetting, location: node.data.location };
+
+    await client.containerApps.beginUpdateAndWait(resourceGroupName, name, updatedApp);
+}

--- a/src/tree/ContainerAppTreeItem.ts
+++ b/src/tree/ContainerAppTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, ContainerAppsAPIClient, ContainerAppSecret } from "@azure/arm-app";
+import { ContainerApp, ContainerAppsAPIClient, ContainerAppSecret } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, parseError, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";
 import { azResourceContextValue, RevisionConstants } from "../constants";

--- a/src/tree/DaprTreeItem.ts
+++ b/src/tree/DaprTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dapr } from "@azure/arm-app";
+import { Dapr } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { azResourceContextValue } from "../constants";
 import { localize } from "../utils/localize";

--- a/src/tree/IngressTreeItem.ts
+++ b/src/tree/IngressTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Ingress } from "@azure/arm-app";
+import { Ingress } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { azResourceContextValue, IngressConstants } from "../constants";

--- a/src/tree/ManagedEnvironmentTreeItem.ts
+++ b/src/tree/ManagedEnvironmentTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerApp, ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-app";
+import { ContainerApp, ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-appcontainers";
 import { LocationListStep, uiUtils, VerifyProvidersStep } from "@microsoft/vscode-azext-azureutils";
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, DialogResponses, IActionContext, ICreateChildImplContext, parseError, TreeItemIconPath, UserCancelledError } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";

--- a/src/tree/RevisionTreeItem.ts
+++ b/src/tree/RevisionTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KnownRevisionProvisioningState, Revision } from "@azure/arm-app";
+import { KnownRevisionProvisioningState, Revision } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ThemeColor, ThemeIcon } from "vscode";
 import { azResourceContextValue } from "../constants";

--- a/src/tree/RevisionsTreeItem.ts
+++ b/src/tree/RevisionsTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient, Revision } from "@azure/arm-app";
+import { ContainerAppsAPIClient, Revision } from "@azure/arm-appcontainers";
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { RevisionConstants } from "../constants";

--- a/src/tree/ScaleRuleGroupTreeItem.ts
+++ b/src/tree/ScaleRuleGroupTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ScaleRule } from "@azure/arm-app";
+import { ScaleRule } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { azResourceContextValue } from "../constants";

--- a/src/tree/ScaleRuleTreeItem.ts
+++ b/src/tree/ScaleRuleTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ScaleRule } from "@azure/arm-app";
+import { ScaleRule } from "@azure/arm-appcontainers";
 import { AzExtTreeItem, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { azResourceContextValue } from "../constants";

--- a/src/tree/ScaleTreeItem.ts
+++ b/src/tree/ScaleTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Scale } from "@azure/arm-app";
+import { Scale } from "@azure/arm-appcontainers";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { azResourceContextValue } from "../constants";

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-app";
+import { ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-appcontainers";
 import { LocationListStep, ResourceGroupCreateStep, SubscriptionTreeItemBase, uiUtils, VerifyProvidersStep } from "@microsoft/vscode-azext-azureutils";
 import { AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
 import { IManagedEnvironmentContext } from '../commands/createManagedEnvironment/IManagedEnvironmentContext';

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerAppsAPIClient } from "@azure/arm-app";
+import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { ContainerRegistryManagementClient, ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { OperationalInsightsManagementClient } from '@azure/arm-operationalinsights';
 import { ContainerRegistryClient, KnownContainerRegistryAudience } from '@azure/container-registry';
@@ -14,7 +14,7 @@ import { AzExtClientContext, createAzureClient, parseClientContext } from '@micr
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
 export async function createContainerAppsAPIClient(context: AzExtClientContext): Promise<ContainerAppsAPIClient> {
-    return createAzureClient(context, (await import('@azure/arm-app')).ContainerAppsAPIClient)
+    return createAzureClient(context, (await import('@azure/arm-appcontainers')).ContainerAppsAPIClient)
 }
 
 export async function createContainerRegistryManagementClient(context: AzExtClientContext): Promise<ContainerRegistryManagementClient> {


### PR DESCRIPTION
The SDK has changed yet again, so updating that.  There's a new update command that doesn't require the _full_ container envelope, so I'm using a new PATCH request that merges the changes of JSON objects.