### PR TITLE
List all tags in all manifests and display time it was created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@azure/ms-rest-js": "^2.2.1",
                 "@microsoft/vscode-azext-azureutils": "^0.1.3",
                 "@microsoft/vscode-azext-utils": "^0.1.0",
+                "dayjs": "^1.11.3",
                 "dotenv": "^16.0.0",
                 "open": "^8.0.4",
                 "semver": "^7.3.5",
@@ -3244,9 +3245,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.10.7",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-            "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
         },
         "node_modules/debug": {
             "version": "4.3.3",
@@ -14481,9 +14482,9 @@
             "dev": true
         },
         "dayjs": {
-            "version": "1.10.7",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-            "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
         },
         "debug": {
             "version": "4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurecontainerapps",
-    "version": "0.1.2-alpha.0",
+    "version": "0.1.2-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurecontainerapps",
-            "version": "0.1.2-alpha.0",
+            "version": "0.1.2-alpha.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appcontainers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -391,6 +391,7 @@
         "@azure/ms-rest-js": "^2.2.1",
         "@microsoft/vscode-azext-azureutils": "^0.1.3",
         "@microsoft/vscode-azext-utils": "^0.1.0",
+        "dayjs": "^1.11.3",
         "dotenv": "^16.0.0",
         "open": "^8.0.4",
         "semver": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurecontainerapps",
     "displayName": "Azure Container Apps",
     "description": "%containerApps.description%",
-    "version": "0.1.2-alpha.0",
+    "version": "0.1.2-alpha.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-containerapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/deployImage/acr/AcrTagListStep.ts
+++ b/src/commands/deployImage/acr/AcrTagListStep.ts
@@ -5,18 +5,27 @@
 
 import { ArtifactManifestProperties } from "@azure/container-registry";
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import * as dayjs from 'dayjs';
+// eslint-disable-next-line import/no-internal-modules
+import * as relativeTime from 'dayjs/plugin/relativeTime';
 import { QuickPickItem } from "vscode";
 import { createContainerRegistryClient } from "../../../utils/azureClients";
 import { nonNullProp, nonNullValue } from "../../../utils/nonNull";
 import { IDeployImageContext } from "../IDeployImageContext";
 import { RepositoryTagListStepBase } from "../RepositoryTagListStepBase";
 
+dayjs.extend(relativeTime);
 export class AcrTagListStep extends RepositoryTagListStepBase {
     public async getPicks(context: IDeployImageContext): Promise<QuickPickItem[]> {
         const client = createContainerRegistryClient(context, nonNullValue(context.registry));
         const repoClient = client.getRepository(nonNullProp(context, 'repositoryName'));
 
         const manifests: ArtifactManifestProperties[] = await uiUtils.listAllIterator(repoClient.listManifestProperties());
-        return manifests[0].tags.map((t) => { { return { label: t } } });
+
+        const tags = manifests.reduce((allTags: { tag: string, date: Date }[], m) => {
+            const tagsWithDates = m.tags.map(t => { return { tag: t, date: m.lastUpdatedOn } });
+            return allTags.concat(tagsWithDates);
+        }, []);
+        return tags.map((t) => { { return { label: t.tag, description: dayjs(t.date).fromNow() } } });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/21

Turns out the problem was the response of the manifest is grouped by the updated date. Previously, I was always grabbing the latest (index 0) manifest and only showing its tags.  Now I reduce it to one array of tags to display all of the tags.

I also went ahead and added descriptions about the last time it was updated. Seemed useful and is modeled after Docker. I believe the timestamps are different because Docker gets the timestamp from the [Docker repository](https://github.com/microsoft/vscode-docker/blob/8746a82b92abf68ee5ddc5a4137b38ff09504dcd/src/tree/registries/dockerV2/DockerV2RepositoryTreeItem.ts#L67-L72) whereas I'm using the ACR response.

![image](https://user-images.githubusercontent.com/5290572/177428265-dd76c2a8-6b1d-4167-8c77-c6e347c14ea7.png)

![image](https://user-images.githubusercontent.com/5290572/177428047-48317b86-b87c-4900-9db7-664cd66d5018.png)
