### PR TITLE
Pass in null rather than undefined

### DIFF
--- a/src/commands/ingressCommands.ts
+++ b/src/commands/ingressCommands.ts
@@ -110,7 +110,7 @@ export async function toggleIngressVisibility(context: IActionContext, node?: In
 
 async function updateIngressSettings(context: IActionContext,
     options: {
-        ingress: Ingress | undefined,
+        ingress: Ingress | null,
         node: IngressTreeItem | IngressDisabledTreeItem,
         working: string,
         workCompleted: string
@@ -119,7 +119,7 @@ async function updateIngressSettings(context: IActionContext,
 
     await window.withProgress({ location: ProgressLocation.Notification, title: working }, async (): Promise<void> => {
         ext.outputChannel.appendLog(working);
-        await updateContainerApp(context, node.parent, { configuration: { ingress: ingress } })
+        await updateContainerApp(context, node.parent, { configuration: { ingress: ingress as Ingress | undefined } })
 
         void window.showInformationMessage(workCompleted);
         ext.outputChannel.appendLog(workCompleted);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/133

Since I'm using a PATCH instead of a POST, the undefined doesn't get picked up and so ingress wasn't being disabled. The request needs to include ingress as null rather than undefined in order for it to be picked up.

Edit: I also noticed that this issue is fixed as well:
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/104

Probably unrelated to this and instead because the package updating to use PATCH rather than POST, but will document that here.