### PR TITLE
Refactor findNearestParent to use context values

### DIFF
--- a/src/commands/scaling/addScaleRule/addScaleRule.ts
+++ b/src/commands/scaling/addScaleRule/addScaleRule.ts
@@ -17,7 +17,7 @@ export async function addScaleRule(context: IActionContext, node?: ScaleRuleGrou
             expectedChildContextValue: new RegExp(ScaleRuleGroupTreeItem.contextValue)
         });
     }
-    const containerApp: ContainerAppTreeItem = treeUtils.findNearestParent(node, ContainerAppTreeItem.prototype);
+    const containerApp: ContainerAppTreeItem = treeUtils.findNearestParent<ContainerAppTreeItem>(node, ContainerAppTreeItem.contextValue);
     await node.createChild(context);
     await containerApp.refresh(context);
 }

--- a/src/tree/ScaleRuleGroupTreeItem.ts
+++ b/src/tree/ScaleRuleGroupTreeItem.ts
@@ -37,8 +37,8 @@ export class ScaleRuleGroupTreeItem extends AzExtParentTreeItem implements IAzur
     }
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
-        const scale: ScaleTreeItem = treeUtils.findNearestParent(this, ScaleTreeItem.prototype);
-        const containerApp: ContainerAppTreeItem = treeUtils.findNearestParent(this, ContainerAppTreeItem.prototype);
+        const scale: ScaleTreeItem = treeUtils.findNearestParent<ScaleTreeItem>(this, ScaleTreeItem.contextValue);
+        const containerApp: ContainerAppTreeItem = treeUtils.findNearestParent<ContainerAppTreeItem>(this, ContainerAppTreeItem.contextValue);
 
         const title: string = localize('addScaleRuleTitle', 'Add Scale Rule');
         const wizardContext: IAddScaleRuleWizardContext = {


### PR DESCRIPTION
To keep the functionality consistent with how it's implemented in Storage.  We can consolidate if we ever decide we want to move this utility into AzureTools.