### PR TITLE
Add increased visibility to the creation of Managed Environments

### DIFF
--- a/src/ContainerAppsResolver.ts
+++ b/src/ContainerAppsResolver.ts
@@ -7,7 +7,7 @@ import { ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-appcontai
 import { getResourceGroupFromId } from "@microsoft/vscode-azext-azureutils";
 import { callWithTelemetryAndErrorHandling, IActionContext, ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "@microsoft/vscode-azext-utils/hostapi";
-import { managedEnvironmentProvider } from "./constants";
+import { managedEnvironmentsAppProvider } from "./constants";
 import { ResolvedContainerEnvironmentResource } from "./tree/ResolvedContainerAppsResource";
 import { createContainerAppsAPIClient } from "./utils/azureClients";
 
@@ -22,6 +22,6 @@ export class ContainerAppsResolver implements AppResourceResolver {
     }
 
     public matchesResource(resource: AppResource): boolean {
-        return resource.type.toLowerCase() === managedEnvironmentProvider.toLowerCase();
+        return resource.type.toLowerCase() === managedEnvironmentsAppProvider.toLowerCase();
     }
 }

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -7,7 +7,7 @@ import { ContainerAppsAPIClient, Ingress, RegistryCredentials, Secret } from "@a
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress } from "vscode";
-import { containerAppProvider, RevisionConstants } from "../../constants";
+import { containerAppsWebProvider, RevisionConstants } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { createContainerAppsAPIClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
@@ -68,7 +68,7 @@ export class ContainerAppCreateStep extends AzureWizardExecuteStep<IContainerApp
         const name = getContainerNameForImage(context.image);
 
         context.containerApp = await appClient.containerApps.beginCreateOrUpdateAndWait(nonNullProp(context, 'newResourceGroupName'), nonNullProp(context, 'newContainerAppName'), {
-            location: (await LocationListStep.getLocation(context, containerAppProvider)).name,
+            location: (await LocationListStep.getLocation(context, containerAppsWebProvider)).name,
             managedEnvironmentId: context.managedEnvironmentId,
             configuration: {
                 ingress,

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -44,8 +44,9 @@ export class ManagedEnvironmentCreateStep extends AzureWizardExecuteStep<IManage
         );
 
         const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container Apps environment "{0}".', context.newManagedEnvironmentName);
+        const viewOutput: string = localize('viewOutput', 'View Output');
         ext.outputChannel.appendLog(createdKuEnv);
-        void window.showInformationMessage(createdKuEnv);
+        void window.showInformationMessage(createdKuEnv, viewOutput).then(() => ext.outputChannel.show());
     }
 
     public shouldExecute(context: IManagedEnvironmentContext): boolean {

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -7,6 +7,7 @@ import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { getResourceGroupFromId, LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress, window } from "vscode";
+import { managedEnvironmentsAppProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { createContainerAppsAPIClient, createOperationalInsightsManagementClient } from '../../utils/azureClients';
 import { localize } from "../../utils/localize";
@@ -42,6 +43,12 @@ export class ManagedEnvironmentCreateStep extends AzureWizardExecuteStep<IManage
                 }
             }
         );
+
+        context.activityResult = {
+            id: nonNullProp(context.managedEnvironment, 'id'),
+            name: nonNullProp(context, 'newManagedEnvironmentName'),
+            type: managedEnvironmentsAppProvider
+        }
 
         const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container Apps environment "{0}".', context.newManagedEnvironmentName);
         const viewOutput: string = localize('viewOutput', 'View Output');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,13 +7,16 @@ import { IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import { QuickPickItem } from "vscode";
 import { localize } from "./utils/localize";
 
-export const webProvider: string = 'Microsoft.Web';
-export const containerAppProvider: string = `${webProvider}/containerApps`;
+export const managedEnvironmentsId = 'managedEnvironments';
+export const containerAppsId = 'containerApps';
 export const appProvider: string = 'Microsoft.App';
-export const managedEnvironmentProvider: string = `${appProvider}/managedEnvironments`;
+export const webProvider: string = 'Microsoft.Web';
+
+export const containerAppsWebProvider: string = `${webProvider}/${containerAppsId}`;
+export const managedEnvironmentsAppProvider: string = `${appProvider}/${managedEnvironmentsId}`;
 
 export const rootFilter = {
-    type: managedEnvironmentProvider
+    type: managedEnvironmentsAppProvider
 }
 
 export namespace IngressConstants {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { AzureExtensionApi, AzureExtensionApiProvider } from '@microsoft/vscode-
 import * as vscode from 'vscode';
 import { revealTreeItem } from './commands/api/revealTreeItem';
 import { registerCommands } from './commands/registerCommands';
-import { managedEnvironmentProvider } from './constants';
+import { managedEnvironmentsAppProvider } from './constants';
 import { ContainerAppsResolver } from './ContainerAppsResolver';
 import { ext } from './extensionVariables';
 import { getResourceGroupsApi } from './getExtensionApi';
@@ -33,7 +33,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.experimentationService = await createExperimentationService(context);
 
         ext.rgApi = await getResourceGroupsApi();
-        ext.rgApi.registerApplicationResourceResolver(managedEnvironmentProvider, new ContainerAppsResolver());
+        ext.rgApi.registerApplicationResourceResolver(managedEnvironmentsAppProvider, new ContainerAppsResolver());
     });
 
     return createApiProvider([<AzureExtensionApi>{

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -39,7 +39,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
     public static async createChild(context: ICreateChildImplContext, node: SubscriptionTreeItemBase): Promise<ManagedEnvironmentTreeItem> {
         const wizardContext: IManagedEnvironmentContext = {
-            ...context, ...node.subscription, ...(await createActivityContext())
+            ...context,
+            ...node.subscription,
+            ...(await createActivityContext())
         };
 
         const title: string = localize('createManagedEnv', 'Create Container Apps environment');


### PR DESCRIPTION
Closes #185 

Added a `View Output` button to the success popup as well as an `activityResult` to the `Activity Log`.

Also did a bit of housekeeping in the `constants` file and the `createChild` method since I was already making changes there for this update.