### PR TITLE
Consolidate `IAzureResource` context constants

### DIFF
--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
-import { rootFilter } from '../constants';
+import { azResourceRegExp, rootFilter } from '../constants';
 import { ext } from '../extensionVariables';
-import { azureResourceRegExp, IAzureResourceTreeItem } from '../tree/IAzureResourceTreeItem';
+import { IAzureResourceTreeItem } from '../tree/IAzureResourceTreeItem';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
 
@@ -14,7 +14,7 @@ export async function viewProperties(context: IActionContext, node?: IAzureResou
     if (!node) {
         node = await ext.rgApi.pickAppResource<IAzureResourceTreeItem>(context, {
             filter: rootFilter,
-            expectedChildContextValue: azureResourceRegExp
+            expectedChildContextValue: azResourceRegExp
         });
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,3 +42,4 @@ export const loadMoreQp: IAzureQuickPickItem = { label: '$(sync) Load More', dat
 export type QuickPicksCache = { cache: QuickPickItem[], next: string | null };
 
 export const azResourceContextValue: string = 'azResource';
+export const azResourceRegExp = new RegExp(azResourceContextValue, 'i');

--- a/src/tree/IAzureResourceTreeItem.ts
+++ b/src/tree/IAzureResourceTreeItem.ts
@@ -15,5 +15,3 @@ export interface IAzureResource {
 }
 
 export interface IAzureResourceTreeItem extends IAzureResource, AzExtTreeItem { }
-
-export const azureResourceRegExp = /azResource/i;


### PR DESCRIPTION
I previously added a context RegExp to a different file when there was already a related one in the `constants` file.  Just wanted to consolidate them while it was fresh on my mind.