### PR TITLE
Display `chooseRevisionMode` update message closer to the end of the update cycle

### DIFF
--- a/src/commands/chooseRevisionMode.ts
+++ b/src/commands/chooseRevisionMode.ts
@@ -48,7 +48,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Contain
             void window.showInformationMessage(updated);
             ext.outputChannel.appendLog(updated);
 
-            await node?.refresh(context);
+            await node?.parent?.refresh(context);
         });
     }
 }


### PR DESCRIPTION
Fixes #195 

Changed the order of calls within the `withProgress` method so that the `update` message is displayed at the end of the actual updates (after the `refresh` method is called, rather than before).