### PR TITLE
Removed use of deprecated `Azure Log Analytics` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
                 "@azure/container-registry": "1.0.0-beta.5",
-                "@azure/monitor-query": "^1.0.2",
                 "@azure/ms-rest-js": "^2.2.1",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
                 "@microsoft/vscode-azext-utils": "^0.3.14",
@@ -431,39 +430,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/@azure/monitor-query": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azure/monitor-query/-/monitor-query-1.0.2.tgz",
-            "integrity": "sha512-wJg6HAjHzO39iokbCAd0wzu5Y7aigQEhJw/b1BWmB64tM1KCYJKLQQppvOKXYRJ5eh68ebinG2n76ogKc6wfmg==",
-            "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-paging": "^1.1.1",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/monitor-query/node_modules/@azure/core-tracing": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/monitor-query/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
@@ -12450,35 +12416,6 @@
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
                     "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-                }
-            }
-        },
-        "@azure/monitor-query": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azure/monitor-query/-/monitor-query-1.0.2.tgz",
-            "integrity": "sha512-wJg6HAjHzO39iokbCAd0wzu5Y7aigQEhJw/b1BWmB64tM1KCYJKLQQppvOKXYRJ5eh68ebinG2n76ogKc6wfmg==",
-            "requires": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-paging": "^1.1.1",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-                    "requires": {
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "tslib": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^4.2.2",
                 "@azure/container-registry": "1.0.0-beta.5",
-                "@azure/loganalytics": "^0.3.0",
+                "@azure/monitor-query": "^1.0.2",
                 "@azure/ms-rest-js": "^2.2.1",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
                 "@microsoft/vscode-azext-utils": "^0.3.14",
@@ -416,16 +416,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
-        "node_modules/@azure/loganalytics": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
-            "integrity": "sha512-rOALuRVTQFn04znlt+BGWIAQltnmrsj3BccGOYBUtcNo/ZC+klgn1rZD0t1+CZmCRcG8UeIddq+88wHP1SF/bQ==",
-            "deprecated": "This package is deprecated in favor of @azure/monitor-query which works both on node.js and browsers",
-            "dependencies": {
-                "@azure/ms-rest-js": "^2.4.0",
-                "tslib": "^1.9.3"
-            }
-        },
         "node_modules/@azure/logger": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -441,6 +431,39 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "node_modules/@azure/monitor-query": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@azure/monitor-query/-/monitor-query-1.0.2.tgz",
+            "integrity": "sha512-wJg6HAjHzO39iokbCAd0wzu5Y7aigQEhJw/b1BWmB64tM1KCYJKLQQppvOKXYRJ5eh68ebinG2n76ogKc6wfmg==",
+            "dependencies": {
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-paging": "^1.1.1",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/monitor-query/node_modules/@azure/core-tracing": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/monitor-query/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
@@ -12415,15 +12438,6 @@
                 }
             }
         },
-        "@azure/loganalytics": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/loganalytics/-/loganalytics-0.3.0.tgz",
-            "integrity": "sha512-rOALuRVTQFn04znlt+BGWIAQltnmrsj3BccGOYBUtcNo/ZC+klgn1rZD0t1+CZmCRcG8UeIddq+88wHP1SF/bQ==",
-            "requires": {
-                "@azure/ms-rest-js": "^2.4.0",
-                "tslib": "^1.9.3"
-            }
-        },
         "@azure/logger": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -12436,6 +12450,35 @@
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
                     "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
+            }
+        },
+        "@azure/monitor-query": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@azure/monitor-query/-/monitor-query-1.0.2.tgz",
+            "integrity": "sha512-wJg6HAjHzO39iokbCAd0wzu5Y7aigQEhJw/b1BWmB64tM1KCYJKLQQppvOKXYRJ5eh68ebinG2n76ogKc6wfmg==",
+            "requires": {
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-paging": "^1.1.1",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "@azure/core-tracing": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+                    "requires": {
+                        "tslib": "^2.2.0"
+                    }
+                },
+                "tslib": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -349,7 +349,6 @@
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",
         "@azure/container-registry": "1.0.0-beta.5",
-        "@azure/monitor-query": "^1.0.2",
         "@azure/ms-rest-js": "^2.2.1",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
         "@microsoft/vscode-azext-utils": "^0.3.14",

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^4.2.2",
         "@azure/container-registry": "1.0.0-beta.5",
-        "@azure/loganalytics": "^0.3.0",
+        "@azure/monitor-query": "^1.0.2",
         "@azure/ms-rest-js": "^2.2.1",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
         "@microsoft/vscode-azext-utils": "^0.3.14",

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -7,7 +7,7 @@ import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { ContainerRegistryManagementClient, ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { OperationalInsightsManagementClient } from '@azure/arm-operationalinsights';
 import { ContainerRegistryClient, KnownContainerRegistryAudience } from '@azure/container-registry';
-import { LogAnalyticsClient } from '@azure/loganalytics';
+import { LogsQueryClient } from '@azure/monitor-query';
 import { AzExtClientContext, createAzureClient, parseClientContext } from '@microsoft/vscode-azext-azureutils';
 
 // Lazy-load @azure packages to improve startup performance.
@@ -32,9 +32,9 @@ export function createContainerRegistryClient(context: AzExtClientContext, regis
         { audience: KnownContainerRegistryAudience.AzureResourceManagerPublicCloud });
 }
 
-export function createLogAnalyticsClient(context: AzExtClientContext): LogAnalyticsClient {
+export function createLogAnalyticsClient(context: AzExtClientContext): LogsQueryClient {
     const clientContext = parseClientContext(context);
-    return new LogAnalyticsClient(clientContext.credentials);
+    return new LogsQueryClient(clientContext.credentials);
 }
 
 export async function createOperationalInsightsManagementClient(context: AzExtClientContext): Promise<OperationalInsightsManagementClient> {

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -7,7 +7,6 @@ import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { ContainerRegistryManagementClient, ContainerRegistryManagementModels } from '@azure/arm-containerregistry';
 import { OperationalInsightsManagementClient } from '@azure/arm-operationalinsights';
 import { ContainerRegistryClient, KnownContainerRegistryAudience } from '@azure/container-registry';
-import { LogsQueryClient } from '@azure/monitor-query';
 import { AzExtClientContext, createAzureClient, parseClientContext } from '@microsoft/vscode-azext-azureutils';
 
 // Lazy-load @azure packages to improve startup performance.
@@ -30,11 +29,6 @@ export function createContainerRegistryClient(context: AzExtClientContext, regis
 
     return new ContainerRegistryClient(`https://${registry.loginServer}`, clientContext.credentials,
         { audience: KnownContainerRegistryAudience.AzureResourceManagerPublicCloud });
-}
-
-export function createLogAnalyticsClient(context: AzExtClientContext): LogsQueryClient {
-    const clientContext = parseClientContext(context);
-    return new LogsQueryClient(clientContext.credentials);
 }
 
 export async function createOperationalInsightsManagementClient(context: AzExtClientContext): Promise<OperationalInsightsManagementClient> {


### PR DESCRIPTION
The dependency has been deprecated in favor of Azure Monitor Query

Edit:  Will just remove the unused package.  Opened a related issue [here](https://github.com/microsoft/vscode-azurecontainerapps/issues/208) for when we add any query support in the future