### PR TITLE
Fix name validation when creating a container app

### DIFF
--- a/src/commands/createContainerApp/ContainerAppNameStep.ts
+++ b/src/commands/createContainerApp/ContainerAppNameStep.ts
@@ -31,8 +31,8 @@ export class ContainerAppNameStep extends AzureWizardPromptStep<IContainerAppCon
         name = name ? name.trim() : '';
         // to prevent showing an error when the character types the first letter
 
-        const { minLength, maxLength } = { minLength: 2, maxLength: 20 };
-        if (!/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name)) {
+        const { minLength, maxLength } = { minLength: 1, maxLength: 32 };
+        if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
             return localize('invalidChar', `A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.`);
         } else if ((name.length < minLength) || name.length > maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', minLength, maxLength);


### PR DESCRIPTION
Fixes #171. 
Fixes #37. 

Validation done in the portal:
![image](https://user-images.githubusercontent.com/59709511/202044422-eefd0d34-bc2f-435e-b1fd-7e987e9ac254.png)

The error also does not seem to pop up when entering only one character. 
