### PR TITLE
Fix `openInPortal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "preview": true,
     "activationEvents": [
         "onCommand:containerApps.viewProperties",
-        "onCommand:containerApps.openLogsInPortal",
+        "onCommand:containerApps.openInPortal",
         "onCommand:containerApps.reportIssue",
         "onCommand:containerApps.createContainerApp",
         "onCommand:containerApps.deployImage",
@@ -73,8 +73,8 @@
                 "category": "Azure Container Apps"
             },
             {
-                "command": "containerApps.openLogsInPortal",
-                "title": "%containerApps.openLogsInPortal%",
+                "command": "containerApps.openInPortal",
+                "title": "%containerApps.openInPortal%",
                 "category": "Azure Container Apps"
             },
             {
@@ -177,6 +177,11 @@
                     "group": "z@1"
                 },
                 {
+                    "command": "containerApps.openInPortal",
+                    "when": "view == azureResourceGroups && viewItem =~ /containerApp[^s]/i",
+                    "group": "z@2"
+                },
+                {
                     "command": "containerApps.createManagedEnvironment",
                     "when": "view == azureResourceGroups && viewItem =~ /azureResourceTypeGroup/i && viewItem =~ /containerAppsEnvironment/i",
                     "group": "2@1"
@@ -265,6 +270,10 @@
             "commandPalette": [
                 {
                     "command": "containerApps.viewProperties",
+                    "when": "never"
+                },
+                {
+                    "command": "containerApps.openInPortal",
                     "when": "never"
                 }
             ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,7 +22,7 @@
     "containerApps.deleteConfirmation": "The behavior to use when confirming delete of a Container Apps environment.",
     "containerApps.deleteConfirmation.EnterName": "Prompts with an input box where you enter the Container Apps environment name to delete.",
     "containerApps.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete.",
-    "containerApps.openLogsInPortal": "Open Logs in Portal",
+    "containerApps.openInPortal": "Open in Portal",
     "containerApps.openConsoleInPortal": "Open Console in Portal",
     "containerApps.editScalingRange": "Edit Scaling Range...",
     "containerApps.addScaleRule": "Add Scale Rule..."

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -4,16 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as azUtil from '@microsoft/vscode-azext-azureutils';
 import { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
-import { rootFilter } from '../constants';
-import { ext } from '../extensionVariables';
-import { LogsTreeItem } from '../tree/LogsTreeItem';
 
-export async function openLogsInPortal(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
-    if (!node) {
-        node = await ext.rgApi.pickAppResource<AzExtTreeItem>(context, {
-            filter: rootFilter,
-            expectedChildContextValue: new RegExp(LogsTreeItem.openLogsContext)
-        });
-    }
+export async function openInPortal(_context: IActionContext, node: AzExtTreeItem): Promise<void> {
     await azUtil.openInPortal(node, node.id ?? node.fullId);
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -18,7 +18,7 @@ import { createManagedEnvironment } from './createManagedEnvironment/createManag
 import { deleteNode } from './deleteNode';
 import { deployImage } from './deployImage/deployImage';
 import { editTargetPort, toggleIngress, toggleIngressVisibility } from './ingressCommands';
-import { openLogsInPortal } from './openLogsInPortal';
+import { openInPortal } from './openInPortal';
 import { changeRevisionActiveState } from './revisionCommands/changeRevisionActiveState';
 import { addScaleRule } from './scaling/addScaleRule/addScaleRule';
 import { editScalingRange } from './scaling/editScalingRange';
@@ -26,7 +26,7 @@ import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
     registerCommand('containerApps.viewProperties', viewProperties);
-    registerCommand('containerApps.openLogsInPortal', openLogsInPortal);
+    registerCommand('containerApps.openInPortal', openInPortal);
     registerCommand('containerApps.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('containerApps.browse', browse);
     registerCommand('containerApps.createManagedEnvironment', createManagedEnvironment);

--- a/src/tree/LogsTreeItem.ts
+++ b/src/tree/LogsTreeItem.ts
@@ -30,8 +30,8 @@ export class LogsTreeItem extends AzExtParentTreeItem {
     public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
         const iconPath = new ThemeIcon('link-external');
         return [
-            new GenericTreeItem(this, { label: 'Open Logs', contextValue: 'openLogs', commandId: 'containerApps.openLogsInPortal', iconPath, id: `${this.parent.id}/logs` }),
-            new GenericTreeItem(this, { label: 'Open Log Stream', contextValue: 'openLogStream', commandId: 'containerApps.openLogsInPortal', iconPath, id: `${this.parent.id}/logstream` })
+            new GenericTreeItem(this, { label: 'Open Logs', contextValue: 'openLogs', commandId: 'containerApps.openInPortal', iconPath, id: `${this.parent.id}/logs` }),
+            new GenericTreeItem(this, { label: 'Open Log Stream', contextValue: 'openLogStream', commandId: 'containerApps.openInPortal', iconPath, id: `${this.parent.id}/logstream` })
         ]
     }
 


### PR DESCRIPTION
I noticed `openInPortal` wasn't showing up for the `containerApp` node.  I think it's likely that this is an artifact of when I initially did the unified migration a few months ago.  I think these changes should fix that.