### PR TITLE
Rethrow errors in `getResourceItem`

### DIFF
--- a/src/tree/ContainerAppsBranchDataProvider.ts
+++ b/src/tree/ContainerAppsBranchDataProvider.ts
@@ -50,6 +50,7 @@ export class ContainerAppsBranchDataProvider extends vscode.Disposable implement
         const resourceItem = await callWithTelemetryAndErrorHandling(
             'getResourceItem',
             async (context: IActionContext) => {
+                context.errorHandling.rethrow = true;
                 const managedEnvironment = await ManagedEnvironmentItem.Get(context, element.subscription, nonNullProp(element, 'resourceGroup'), element.name);
                 return new ManagedEnvironmentItem(element.subscription, element, managedEnvironment);
             });


### PR DESCRIPTION
Working towards #240 

This will enable showing this once the necessary changes are made in RGs
<img width="343" alt="image" src="https://user-images.githubusercontent.com/12476526/216724253-0d333d2b-5173-4a81-a9fe-f859d6eb2ffc.png">
