### PR TITLE
Remove `View Output` popup after creation of Container Apps Environment

### DIFF
--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -6,7 +6,7 @@
 import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { getResourceGroupFromId, LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
-import { Progress, window } from "vscode";
+import { Progress } from "vscode";
 import { managedEnvironmentsAppProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { createContainerAppsAPIClient, createOperationalInsightsManagementClient } from '../../utils/azureClients';
@@ -51,9 +51,7 @@ export class ManagedEnvironmentCreateStep extends AzureWizardExecuteStep<IManage
         }
 
         const createdKuEnv: string = localize('createKuEnv', 'Successfully created new Container Apps environment "{0}".', context.newManagedEnvironmentName);
-        const viewOutput: string = localize('viewOutput', 'View Output');
         ext.outputChannel.appendLog(createdKuEnv);
-        void window.showInformationMessage(createdKuEnv, viewOutput).then(() => ext.outputChannel.show());
     }
 
     public shouldExecute(context: IManagedEnvironmentContext): boolean {


### PR DESCRIPTION
Fixes #241 

Removing based on our talk in standup.... 

This is already basically captured with the Activity Log, so no need to show the extra popup anyway.