### PR TITLE
Use PAT for version bumper workflow

### DIFF
--- a/.github/workflows/bump-version-pr.yaml
+++ b/.github/workflows/bump-version-pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Bump version
         id: bump
         uses: alexweininger/bump-prerelease-version@v0.1.1
-      
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -25,6 +25,7 @@ jobs:
           branch: bot/bump-${{ steps.bump.outputs.new-version }}
           base: main
           author: GitHub <noreply@github.com>
+          with: ${{ secrets.PAT_GITHUB }}
         env:
           RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MESSAGE: Bump version after release


### PR DESCRIPTION
See https://docs.opensource.microsoft.com/releasing/securing-content/github-actions-security-announcement/

and https://github.com/microsoft/github-operations/issues/232