### PR TITLE
Add Container App Environment refresh for deploy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Add container app update call back to `deployImage` by @MicroFish91 in [#266](https://github.com/microsoft/vscode-azurecontainerapps/pull/266)
+* Fix `deployImage` by @MicroFish91 in [#266](https://github.com/microsoft/vscode-azurecontainerapps/pull/266) & [#267](https://github.com/microsoft/vscode-azurecontainerapps/pull/267)
 * Remove legacy reference to `rgApi` by @MicroFish91 in [#264](https://github.com/microsoft/vscode-azurecontainerapps/pull/264)
 
 ## 0.4.0 - 2023-02-22

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -9,7 +9,8 @@ import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createSubsc
 import { MessageItem, ProgressLocation, window } from "vscode";
 import { acrDomain, webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { ContainerAppItem, getContainerEnvelopeWithSecrets, refreshContainerApp } from "../../tree/ContainerAppItem";
+import { ContainerAppItem, getContainerEnvelopeWithSecrets } from "../../tree/ContainerAppItem";
+import { refreshContainerAppEnvironment } from "../../tree/ManagedEnvironmentItem";
 import { createContainerAppsAPIClient } from '../../utils/azureClients';
 import { localize } from "../../utils/localize";
 import { pickContainerApp } from "../../utils/pickContainerApp";
@@ -95,7 +96,7 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
             void showContainerAppCreated(updatedContainerApp, true);
         });
 
-        refreshContainerApp(containerApp.id);
+        refreshContainerAppEnvironment(containerApp.managedEnvironmentId);
     });
 }
 

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -10,7 +10,7 @@ import { MessageItem, ProgressLocation, window } from "vscode";
 import { acrDomain, webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { ContainerAppItem, getContainerEnvelopeWithSecrets } from "../../tree/ContainerAppItem";
-import { refreshContainerAppEnvironment } from "../../tree/ManagedEnvironmentItem";
+import { refreshManagedEnvironment } from "../../tree/ManagedEnvironmentItem";
 import { createContainerAppsAPIClient } from '../../utils/azureClients';
 import { localize } from "../../utils/localize";
 import { pickContainerApp } from "../../utils/pickContainerApp";
@@ -96,7 +96,7 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
             void showContainerAppCreated(updatedContainerApp, true);
         });
 
-        refreshContainerAppEnvironment(containerApp.managedEnvironmentId);
+        refreshManagedEnvironment(containerApp.managedEnvironmentId);
     });
 }
 

--- a/src/tree/ManagedEnvironmentItem.ts
+++ b/src/tree/ManagedEnvironmentItem.ts
@@ -16,11 +16,11 @@ import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataPro
 
 type ManagedEnvironmentModel = ManagedEnvironment & ResourceModel;
 
-const refreshContainerAppEnvironmentEmitter = new EventEmitter<string>();
-const refreshContainerAppEnvironmentEvent = refreshContainerAppEnvironmentEmitter.event;
+const refreshManagedEnvironmentEmitter = new EventEmitter<string>();
+const refreshManagedEnvironmentEvent = refreshManagedEnvironmentEmitter.event;
 
-export function refreshContainerAppEnvironment(id: string): void {
-    refreshContainerAppEnvironmentEmitter.fire(id);
+export function refreshManagedEnvironment(id: string): void {
+    refreshManagedEnvironmentEmitter.fire(id);
 }
 
 export class ManagedEnvironmentItem implements TreeElementBase {
@@ -40,7 +40,7 @@ export class ManagedEnvironmentItem implements TreeElementBase {
         this.id = this.managedEnvironment.id;
         this.resourceGroup = this.managedEnvironment.resourceGroup;
         this.name = this.managedEnvironment.name;
-        refreshContainerAppEnvironmentEvent((id) => {
+        refreshManagedEnvironmentEvent((id) => {
             if (id === this.id) {
                 void this.refresh();
             }
@@ -48,7 +48,7 @@ export class ManagedEnvironmentItem implements TreeElementBase {
     }
 
     private async refresh(): Promise<void> {
-        await callWithTelemetryAndErrorHandling('containerAppEnvironmentItem.refresh', async (context) => {
+        await callWithTelemetryAndErrorHandling('managedEnvironmentItem.refresh', async (context) => {
             const client: ContainerAppsAPIClient = await createContainerAppsClient(context, this.subscription);
             this._managedEnvironment = ManagedEnvironmentItem.CreateManagedEnvironmentModel(await client.managedEnvironments.get(this.resourceGroup, this.name));
             ext.branchDataProvider.refresh(this);

--- a/src/tree/ManagedEnvironmentItem.ts
+++ b/src/tree/ManagedEnvironmentItem.ts
@@ -48,7 +48,7 @@ export class ManagedEnvironmentItem implements TreeElementBase {
     }
 
     private async refresh(): Promise<void> {
-        await callWithTelemetryAndErrorHandling('containerAppItem.refresh', async (context) => {
+        await callWithTelemetryAndErrorHandling('containerAppEnvironmentItem.refresh', async (context) => {
             const client: ContainerAppsAPIClient = await createContainerAppsClient(context, this.subscription);
             this._managedEnvironment = ManagedEnvironmentItem.CreateManagedEnvironmentModel(await client.managedEnvironments.get(this.resourceGroup, this.name));
             ext.branchDataProvider.refresh(this);


### PR DESCRIPTION
Children of the CA were updating, but view properties on the Container App wasn't, so switching the node we refresh to the container app environment