### PR TITLE
Refresh CAE children instead of trying to refresh individual CAs

### DIFF
--- a/src/commands/chooseRevisionMode.ts
+++ b/src/commands/chooseRevisionMode.ts
@@ -7,7 +7,7 @@ import { KnownActiveRevisionsMode } from "@azure/arm-appcontainers";
 import { IActionContext, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";
 import { ext } from "../extensionVariables";
-import { ContainerAppModel, refreshContainerApp } from "../tree/ContainerAppItem";
+import { ContainerAppModel } from "../tree/ContainerAppItem";
 import { ContainerAppsItem } from "../tree/ContainerAppsBranchDataProvider";
 import { localize } from "../utils/localize";
 import { pickContainerApp } from "../utils/pickContainerApp";
@@ -24,7 +24,7 @@ export async function chooseRevisionMode(context: IActionContext, node?: Contain
 
         await window.withProgress({ location: ProgressLocation.Notification, title: updating }, async (): Promise<void> => {
             await updateContainerApp(context, subscription, containerApp, { configuration: { activeRevisionsMode: pickedRevisionMode } });
-            refreshContainerApp(containerApp.id);
+            ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
         });
 
         const updated = localize('updatedRevision', 'Updated revision mode of "{0}" to "{1}".', containerApp.name, pickedRevisionMode);

--- a/src/commands/deployImage/deployImage.ts
+++ b/src/commands/deployImage/deployImage.ts
@@ -9,7 +9,7 @@ import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createSubsc
 import { MessageItem, ProgressLocation, window } from "vscode";
 import { acrDomain, webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { ContainerAppItem, getContainerEnvelopeWithSecrets, refreshContainerApp } from "../../tree/ContainerAppItem";
+import { ContainerAppItem, getContainerEnvelopeWithSecrets } from "../../tree/ContainerAppItem";
 import { createContainerAppsAPIClient } from '../../utils/azureClients';
 import { localize } from "../../utils/localize";
 import { pickContainerApp } from "../../utils/pickContainerApp";
@@ -95,7 +95,7 @@ export async function deployImage(context: ITreeItemPickerContext & Partial<IDep
             void showContainerAppCreated(updatedContainerApp, true);
         });
 
-        refreshContainerApp(containerApp.id);
+        ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
     });
 }
 

--- a/src/commands/scaling/editScalingRange.ts
+++ b/src/commands/scaling/editScalingRange.ts
@@ -6,7 +6,6 @@
 import { IActionContext, nonNullValue } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";
 import { ext } from "../../extensionVariables";
-import { refreshContainerApp } from "../../tree/ContainerAppItem";
 import { ScaleItem } from "../../tree/scaling/ScaleItem";
 import { localize } from "../../utils/localize";
 import { updateContainerApp } from "../updateContainerApp";
@@ -38,7 +37,7 @@ export async function editScalingRange(context: IActionContext, node?: ScaleItem
     await window.withProgress({ location: ProgressLocation.Notification, title: updating }, async (): Promise<void> => {
         ext.outputChannel.appendLog(updating);
         await updateContainerApp(context, subscription, containerApp, { template })
-        refreshContainerApp(containerApp.id);
+        ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
         void window.showInformationMessage(updated);
         ext.outputChannel.appendLog(updated);
     });

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -51,11 +51,9 @@ export class ContainerAppItem implements ContainerAppsItem {
         this.name = this.containerApp.name;
     }
 
-    get viewProperties(): ViewPropertiesModel {
-        return {
-            data: this.containerApp,
-            label: this.containerApp.name,
-        }
+    viewProperties: ViewPropertiesModel = {
+        data: this.containerApp,
+        label: this.containerApp.name,
     }
 
     portalUrl: Uri = createPortalUrl(this.subscription, this.containerApp.id);

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -7,7 +7,7 @@ import { ContainerApp, ContainerAppsAPIClient, KnownActiveRevisionsMode } from "
 import { getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizard, callWithTelemetryAndErrorHandling, createSubscriptionContext, DeleteConfirmationStep, IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { AzureSubscription, ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
-import { EventEmitter, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
+import { TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import { DeleteAllContainerAppsStep } from "../commands/deleteContainerApp/DeleteAllContainerAppsStep";
 import { IDeleteContainerAppWizardContext } from "../commands/deleteContainerApp/IDeleteContainerAppWizardContext";
 import { ext } from "../extensionVariables";
@@ -22,13 +22,6 @@ import { IngressDisabledItem, IngressItem } from "./IngressItem";
 import { LogsItem } from "./LogsItem";
 import { RevisionsItem } from "./RevisionsItem";
 import { ScaleItem } from "./scaling/ScaleItem";
-
-const refreshContainerAppEmitter = new EventEmitter<string>();
-const refreshContainerAppEvent = refreshContainerAppEmitter.event;
-
-export function refreshContainerApp(id: string): void {
-    refreshContainerAppEmitter.fire(id);
-}
 
 export interface ContainerAppModel extends ContainerApp {
     id: string;
@@ -56,24 +49,13 @@ export class ContainerAppItem implements ContainerAppsItem {
         this.id = this.containerApp.id;
         this.resourceGroup = this.containerApp.resourceGroup;
         this.name = this.containerApp.name;
-        refreshContainerAppEvent((id) => {
-            if (id === this.id) {
-                void this.refresh();
-            }
-        })
     }
 
-    private async refresh(): Promise<void> {
-        await callWithTelemetryAndErrorHandling('containerAppItem.refresh', async (context) => {
-            const client: ContainerAppsAPIClient = await createContainerAppsClient(context, this.subscription);
-            this._containerApp = ContainerAppItem.CreateContainerAppModel(await client.containerApps.get(this.resourceGroup, this.name));
-            ext.branchDataProvider.refresh(this);
-        });
-    }
-
-    viewProperties: ViewPropertiesModel = {
-        data: this.containerApp,
-        label: this.containerApp.name,
+    get viewProperties(): ViewPropertiesModel {
+        return {
+            data: this.containerApp,
+            label: this.containerApp.name,
+        }
     }
 
     portalUrl: Uri = createPortalUrl(this.subscription, this.containerApp.id);


### PR DESCRIPTION
Children of the CA were updating, but view properties on the Container App wasn't, so switching the node we refresh to the container app environment itself. That way the CA items are recreated.