### PR TITLE
Expand image source selection for creating Container Apps

### DIFF
--- a/src/commands/createContainerApp/IContainerAppContext.ts
+++ b/src/commands/createContainerApp/IContainerAppContext.ts
@@ -5,11 +5,13 @@
 
 import { IResourceGroupWizardContext } from '@microsoft/vscode-azext-azureutils';
 import { ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
+import { ImageSourceValues } from '../../constants';
 import { ContainerAppModel } from "../../tree/ContainerAppItem";
 import { IDeployImageContext } from '../deployImage/IDeployImageContext';
 export interface IContainerAppContext extends IResourceGroupWizardContext, IDeployImageContext {
     managedEnvironmentId: string;
     newContainerAppName?: string;
+    imageSource?: ImageSourceValues;
 
     enableIngress?: boolean;
     enableExternal?: boolean;

--- a/src/commands/createContainerApp/ImageSourceListStep.ts
+++ b/src/commands/createContainerApp/ImageSourceListStep.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, openUrl } from "@microsoft/vscode-azext-utils";
+import { ImageSource, ImageSourceValues, quickStartImageName } from "../../constants";
+import { localize } from "../../utils/localize";
+import { ContainerRegistryListStep } from "../deployImage/ContainerRegistryListStep";
+import { EnvironmentVariablesListStep } from "./EnvironmentVariablesListStep";
+import { IContainerAppContext } from './IContainerAppContext';
+
+export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppContext> {
+    public async prompt(context: IContainerAppContext): Promise<void> {
+        const imageSourceLabels: string[] = [
+            'Quick Start',
+            'Registry'
+        ];
+        const imageSourceInfo: string = localize('imageSourceInfo', '$(link-external)  Learn more about the different image source options');
+
+        const placeHolder: string = localize('imageBuildSourcePrompt', 'Choose an image source for the container app.');
+        const picks: IAzureQuickPickItem<ImageSourceValues | undefined>[] = [
+            { label: imageSourceLabels[0], data: ImageSource.QuickStart, description: quickStartImageName, suppressPersistence: true },
+            { label: imageSourceLabels[1], data: ImageSource.Registry, description: 'Azure Container Registry, Docker Hub, etc.', suppressPersistence: true },
+            { label: imageSourceInfo, data: undefined, suppressPersistence: true }
+        ]
+
+        let pick: ImageSourceValues | undefined;
+        while (!pick) {
+            pick = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+            if (!pick) {
+                // Todo: add wiki url and populate info...
+                await openUrl('https://aka.ms/');
+            }
+        }
+        context.imageSource = pick;
+    }
+
+    public shouldPrompt(context: IContainerAppContext): boolean {
+        return !context.imageSource;
+    }
+
+    public async getSubWizard(context: IContainerAppContext): Promise<IWizardOptions<IContainerAppContext> | undefined> {
+        const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] = [];
+        switch (context.imageSource) {
+            case ImageSource.QuickStart:
+                // Todo: @mmott
+                break;
+            case ImageSource.Registry:
+                promptSteps.push(new ContainerRegistryListStep(), new EnvironmentVariablesListStep());
+                break;
+            case ImageSource.LocalDocker:
+                // Todo: Migrate or leverage from Docker Ext.
+                break;
+            case ImageSource.AcrDocker:
+                // Todo: Migrate or leverage from Docker Ext.
+                break;
+            default:
+        }
+
+        return { promptSteps };
+    }
+}

--- a/src/commands/createContainerApp/ImageSourceListStep.ts
+++ b/src/commands/createContainerApp/ImageSourceListStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, openUrl } from "@microsoft/vscode-azext-utils";
+import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from "@microsoft/vscode-azext-utils";
 import { ImageSource, ImageSourceValues } from "../../constants";
 import { localize } from "../../utils/localize";
 import { ContainerRegistryListStep } from "../deployImage/ContainerRegistryListStep";
@@ -13,37 +13,19 @@ import { IContainerAppContext } from './IContainerAppContext';
 export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppContext> {
     public async prompt(context: IContainerAppContext): Promise<void> {
         const imageSourceLabels: string[] = [
-            localize('quickStartImage', 'Quick Start Image'),
-            localize('externalRegistry', 'External Registry'),
-            localize('localDockerBuild', 'Local Docker Build'),
-            localize('azureRemoteBuild', 'Azure Registry Build')
+            localize('quickStartImage', 'Use quickstart image'),
+            localize('externalRegistry', 'Use existing image'),
+            localize('buildFromProject', 'Build from project'),
         ];
-        const imageSourceDescriptions: string[] = [
-            localize('quickStartDesc', 'Default image choice for fast setup'),
-            localize('externalRegistryDesc', 'Use an existing image stored in a registry'),
-            localize('localDockerBuildDesc', 'Build image from project locally using Docker'),
-            localize('azureRemoteBuildDesc', 'Build image from project remotely using Azure')
-        ];
-        const imageSourceInfo: string = localize('imageSourceInfo', '$(link-external)  Learn more about the different image source options');
 
-        const placeHolder: string = localize('imageBuildSourcePrompt', 'Choose an image source for the container app');
+        const placeHolder: string = localize('imageBuildSourcePrompt', 'Select an image source for the container app');
         const picks: IAzureQuickPickItem<ImageSourceValues | undefined>[] = [
-            { label: imageSourceLabels[0], description: imageSourceDescriptions[0], data: ImageSource.QuickStartImage,  suppressPersistence: true },
-            { label: imageSourceLabels[1], description: imageSourceDescriptions[1], data: ImageSource.ExternalRegistry, suppressPersistence: true },
-            { label: imageSourceLabels[2], description: imageSourceDescriptions[2], data: ImageSource.LocalDockerBuild, suppressPersistence: true },
-            { label: imageSourceLabels[3], description: imageSourceDescriptions[3], data: ImageSource.RemoteAcrBuild, suppressPersistence: true},
-            { label: imageSourceInfo, data: undefined, suppressPersistence: true }
-        ]
+            { label: imageSourceLabels[0], data: ImageSource.QuickStartImage,  suppressPersistence: true },
+            { label: imageSourceLabels[1], data: ImageSource.ExternalRegistry, suppressPersistence: true },
+            { label: imageSourceLabels[2], data: undefined, suppressPersistence: true },
+        ];
 
-        let pick: ImageSourceValues | undefined;
-        while (!pick) {
-            pick = (await context.ui.showQuickPick(picks, { placeHolder })).data;
-            if (!pick) {
-                // Todo: add wiki url and populate info...
-                await openUrl('https://aka.ms/');
-            }
-        }
-        context.imageSource = pick;
+        context.imageSource = (await context.ui.showQuickPick(picks, { placeHolder })).data;
     }
 
     public shouldPrompt(context: IContainerAppContext): boolean {
@@ -58,13 +40,8 @@ export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppCont
             case ImageSource.ExternalRegistry:
                 promptSteps.push(new ContainerRegistryListStep(), new EnvironmentVariablesListStep());
                 break;
-            case ImageSource.LocalDockerBuild:
-                // Todo: Migrate or leverage from Docker Ext.
-                break;
-            case ImageSource.RemoteAcrBuild:
-                // Todo: Migrate or leverage from Docker Ext.
-                break;
             default:
+                // Todo: Steps that lead to additional 'Build from project' options
         }
 
         return { promptSteps };

--- a/src/commands/createContainerApp/ImageSourceListStep.ts
+++ b/src/commands/createContainerApp/ImageSourceListStep.ts
@@ -15,14 +15,14 @@ export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppCont
         const imageSourceLabels: string[] = [
             localize('quickStartImage', 'Use quickstart image'),
             localize('externalRegistry', 'Use existing image'),
-            localize('buildFromProject', 'Build from project'),
+            // localize('buildFromProject', 'Build from project'),
         ];
 
         const placeHolder: string = localize('imageBuildSourcePrompt', 'Select an image source for the container app');
         const picks: IAzureQuickPickItem<ImageSourceValues | undefined>[] = [
             { label: imageSourceLabels[0], data: ImageSource.QuickStartImage,  suppressPersistence: true },
             { label: imageSourceLabels[1], data: ImageSource.ExternalRegistry, suppressPersistence: true },
-            { label: imageSourceLabels[2], data: undefined, suppressPersistence: true },
+            // { label: imageSourceLabels[2], data: undefined, suppressPersistence: true },
         ];
 
         context.imageSource = (await context.ui.showQuickPick(picks, { placeHolder })).data;
@@ -34,9 +34,11 @@ export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppCont
 
     public async getSubWizard(context: IContainerAppContext): Promise<IWizardOptions<IContainerAppContext> | undefined> {
         const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] = [];
+
         switch (context.imageSource) {
             case ImageSource.QuickStartImage:
                 // Todo: @mmott
+                throw new Error('Not implemented yet');
             case ImageSource.ExternalRegistry:
                 promptSteps.push(new ContainerRegistryListStep(), new EnvironmentVariablesListStep());
                 break;

--- a/src/commands/createContainerApp/ImageSourceListStep.ts
+++ b/src/commands/createContainerApp/ImageSourceListStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, openUrl } from "@microsoft/vscode-azext-utils";
-import { ImageSource, ImageSourceValues, quickStartImageName } from "../../constants";
+import { ImageSource, ImageSourceValues } from "../../constants";
 import { localize } from "../../utils/localize";
 import { ContainerRegistryListStep } from "../deployImage/ContainerRegistryListStep";
 import { EnvironmentVariablesListStep } from "./EnvironmentVariablesListStep";
@@ -13,15 +13,25 @@ import { IContainerAppContext } from './IContainerAppContext';
 export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppContext> {
     public async prompt(context: IContainerAppContext): Promise<void> {
         const imageSourceLabels: string[] = [
-            'Quick Start',
-            'Registry'
+            localize('quickStartImage', 'Quick Start Image'),
+            localize('externalRegistry', 'External Registry'),
+            localize('localDockerBuild', 'Local Docker Build'),
+            localize('azureRemoteBuild', 'Azure Registry Build')
+        ];
+        const imageSourceDescriptions: string[] = [
+            localize('quickStartDesc', 'Default image choice for fast setup'),
+            localize('externalRegistryDesc', 'Use an existing image stored in a registry'),
+            localize('localDockerBuildDesc', 'Build image from project locally using Docker'),
+            localize('azureRemoteBuildDesc', 'Build image from project remotely using Azure')
         ];
         const imageSourceInfo: string = localize('imageSourceInfo', '$(link-external)  Learn more about the different image source options');
 
-        const placeHolder: string = localize('imageBuildSourcePrompt', 'Choose an image source for the container app.');
+        const placeHolder: string = localize('imageBuildSourcePrompt', 'Choose an image source for the container app');
         const picks: IAzureQuickPickItem<ImageSourceValues | undefined>[] = [
-            { label: imageSourceLabels[0], data: ImageSource.QuickStart, description: quickStartImageName, suppressPersistence: true },
-            { label: imageSourceLabels[1], data: ImageSource.Registry, description: 'Azure Container Registry, Docker Hub, etc.', suppressPersistence: true },
+            { label: imageSourceLabels[0], description: imageSourceDescriptions[0], data: ImageSource.QuickStartImage,  suppressPersistence: true },
+            { label: imageSourceLabels[1], description: imageSourceDescriptions[1], data: ImageSource.ExternalRegistry, suppressPersistence: true },
+            { label: imageSourceLabels[2], description: imageSourceDescriptions[2], data: ImageSource.LocalDockerBuild, suppressPersistence: true },
+            { label: imageSourceLabels[3], description: imageSourceDescriptions[3], data: ImageSource.RemoteAcrBuild, suppressPersistence: true},
             { label: imageSourceInfo, data: undefined, suppressPersistence: true }
         ]
 
@@ -43,16 +53,15 @@ export class ImageSourceListStep extends AzureWizardPromptStep<IContainerAppCont
     public async getSubWizard(context: IContainerAppContext): Promise<IWizardOptions<IContainerAppContext> | undefined> {
         const promptSteps: AzureWizardPromptStep<IContainerAppContext>[] = [];
         switch (context.imageSource) {
-            case ImageSource.QuickStart:
+            case ImageSource.QuickStartImage:
                 // Todo: @mmott
-                break;
-            case ImageSource.Registry:
+            case ImageSource.ExternalRegistry:
                 promptSteps.push(new ContainerRegistryListStep(), new EnvironmentVariablesListStep());
                 break;
-            case ImageSource.LocalDocker:
+            case ImageSource.LocalDockerBuild:
                 // Todo: Migrate or leverage from Docker Ext.
                 break;
-            case ImageSource.AcrDocker:
+            case ImageSource.RemoteAcrBuild:
                 // Todo: Migrate or leverage from Docker Ext.
                 break;
             default:

--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -16,7 +16,7 @@ import { ContainerAppCreateStep } from "./ContainerAppCreateStep";
 import { ContainerAppNameStep } from "./ContainerAppNameStep";
 import { EnableIngressStep } from "./EnableIngressStep";
 import { IContainerAppContext, IContainerAppWithActivityContext } from "./IContainerAppContext";
-import { ImageSourceListStep } from "./ImageSourceListSTep";
+import { ImageSourceListStep } from "./ImageSourceListStep";
 import { showContainerAppCreated } from "./showContainerAppCreated";
 
 export async function createContainerApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IContainerAppContext>, node?: ManagedEnvironmentItem): Promise<ContainerAppItem> {

--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -12,12 +12,11 @@ import { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
 import { createActivityContext } from "../../utils/activityUtils";
 import { localize } from "../../utils/localize";
 import { containerAppEnvironmentExperience } from "../../utils/pickContainerApp";
-import { ContainerRegistryListStep } from "../deployImage/ContainerRegistryListStep";
 import { ContainerAppCreateStep } from "./ContainerAppCreateStep";
 import { ContainerAppNameStep } from "./ContainerAppNameStep";
 import { EnableIngressStep } from "./EnableIngressStep";
-import { EnvironmentVariablesListStep } from "./EnvironmentVariablesListStep";
 import { IContainerAppContext, IContainerAppWithActivityContext } from "./IContainerAppContext";
+import { ImageSourceListStep } from "./ImageSourceListSTep";
 import { showContainerAppCreated } from "./showContainerAppCreated";
 
 export async function createContainerApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IContainerAppContext>, node?: ManagedEnvironmentItem): Promise<ContainerAppItem> {
@@ -36,8 +35,7 @@ export async function createContainerApp(context: IActionContext & Partial<ICrea
 
     const promptSteps: AzureWizardPromptStep<IContainerAppWithActivityContext>[] = [
         new ContainerAppNameStep(),
-        new ContainerRegistryListStep(),
-        new EnvironmentVariablesListStep(),
+        new ImageSourceListStep(),
         new EnableIngressStep(),
     ];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,7 @@ export enum ScaleRuleTypes {
 
 export enum ImageSource {
     /*
-     * Use the default hello-world image with preset configurations
+     * Uses the default hello-world image with preset configurations
      */
     QuickStartImage = 'quickStartImage',
     /*

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,21 +38,21 @@ export enum ScaleRuleTypes {
 
 export enum ImageSource {
     /*
-     * Use default placeholder image and configurations
+     * Use the default hello-world image with preset configurations
      */
-    QuickStart = 'quickStart',
+    QuickStartImage = 'quickStartImage',
     /*
-     * Use an image hosted in ACR or a third party registry
+     * Use an image stored in ACR or a third party registry
      */
-    Registry = 'registry',
+    ExternalRegistry = 'externalRegistry',
     /*
-     * Use an image that is built first locally using Docker (w/ Dockerfile)
+     * Build the image from your project locally using Docker (reqs. Dockerfile)
      */
-    LocalDocker = 'localDocker',
+    LocalDockerBuild = 'localDockerBuild',
     /*
-     * Use an image that is built in ACR from uploaded project files (w/ Dockerfile)
+     * Build the image from your project remotely using ACR (reqs. Dockerfile)
      */
-    AcrDocker = 'acrDocker'
+    RemoteAcrBuild = 'remoteAcrBuild'
 }
 
 export type ImageSourceValues = typeof ImageSource[keyof typeof ImageSource];
@@ -60,8 +60,6 @@ export type ImageSourceValues = typeof ImageSource[keyof typeof ImageSource];
 export const acrDomain = 'azurecr.io';
 export const dockerHubDomain = 'docker.io';
 export const dockerHubRegistry = 'index.docker.io';
-
-export const quickStartImageName = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest';
 
 export type SupportedRegistries = 'azurecr.io' | 'docker.io';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,9 +36,32 @@ export enum ScaleRuleTypes {
     Queue = "Azure queue"
 }
 
+export enum ImageSource {
+    /*
+     * Use default placeholder image and configurations
+     */
+    QuickStart = 'quickStart',
+    /*
+     * Use an image hosted in ACR or a third party registry
+     */
+    Registry = 'registry',
+    /*
+     * Use an image that is built first locally using Docker (w/ Dockerfile)
+     */
+    LocalDocker = 'localDocker',
+    /*
+     * Use an image that is built in ACR from uploaded project files (w/ Dockerfile)
+     */
+    AcrDocker = 'acrDocker'
+}
+
+export type ImageSourceValues = typeof ImageSource[keyof typeof ImageSource];
+
 export const acrDomain = 'azurecr.io';
 export const dockerHubDomain = 'docker.io';
 export const dockerHubRegistry = 'index.docker.io';
+
+export const quickStartImageName = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest';
 
 export type SupportedRegistries = 'azurecr.io' | 'docker.io';
 


### PR DESCRIPTION
Closes #271 

New image source list step provides the following options:

![image](https://user-images.githubusercontent.com/40250218/221319454-7a66b705-cd4f-4606-b893-6782dfaa43e3.png)

`Build from project` related choices will be added in future PRs once implemented...