### PR TITLE
Suggest values during steps when deploying image from ACR

### DIFF
--- a/src/commands/createContainerApp/setQuickStartImage.ts
+++ b/src/commands/createContainerApp/setQuickStartImage.ts
@@ -3,10 +3,11 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import { quickStartImageName } from "../../constants";
 import { IContainerAppContext } from "./IContainerAppContext";
 
 export function setQuickStartImage(context: Partial<IContainerAppContext>): void {
-    context.image = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest';
+    context.image = quickStartImageName;
     context.enableIngress = true;
     context.enableExternal = true;
     context.targetPort = 80;

--- a/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
@@ -39,11 +39,11 @@ export class AcrListStep extends AzureWizardPromptStep<IContainerRegistryImageCo
         const registries: Registry[] = await uiUtils.listAllIterator(client.registries.list());
 
         const containerApp: ContainerAppModel = nonNullProp(context, 'targetContainer');
-        const { registryDomain, registryName, referenceImageName } = parseImageName(getLatestContainerAppImage(containerApp));
+        const { registryDomain, registryName, imageNameReference } = parseImageName(getLatestContainerAppImage(containerApp));
 
         // If the image is not the default quickstart image, then we can try to suggest a registry based on the latest Container App image
         let suggestedRegistry: string | undefined;
-        if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
+        if (registryDomain === acrDomain && imageNameReference !== quickStartImageName) {
             suggestedRegistry = registryName;
         }
 

--- a/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
@@ -50,7 +50,6 @@ export class AcrListStep extends AzureWizardPromptStep<IContainerRegistryImageCo
         // Does the suggested registry exist in the list of pulled registries?  If so, move it to the front of the list
         const srIndex: number = registries.findIndex((r) => !!suggestedRegistry && r.loginServer === suggestedRegistry);
         const srExists: boolean = srIndex !== -1;
-
         if (srExists) {
             const sr: Registry = registries.splice(srIndex, 1)[0];
             registries.unshift(sr);

--- a/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
@@ -6,7 +6,9 @@
 import type { ContainerRegistryManagementClient, Registry } from "@azure/arm-containerregistry";
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from "@microsoft/vscode-azext-utils";
+import { acrDomain, quickStartImageName } from "../../../../constants";
 import { createContainerRegistryManagementClient } from "../../../../utils/azureClients";
+import { parseImageName } from "../../../../utils/imageNameUtils";
 import { localize } from "../../../../utils/localize";
 import { nonNullProp } from "../../../../utils/nonNull";
 import { IContainerRegistryImageContext } from "../IContainerRegistryImageContext";
@@ -14,8 +16,15 @@ import { RegistryEnableAdminUserStep } from "./RegistryEnableAdminUserStep";
 
 export class AcrListStep extends AzureWizardPromptStep<IContainerRegistryImageContext> {
     public async prompt(context: IContainerRegistryImageContext): Promise<void> {
+        const { registryDomain, registryName, referenceImageName } = parseImageName(context.targetContainer?.template?.containers?.[0]?.image);
+
+        let predictedRegistry: string | undefined;
+        if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
+            predictedRegistry = registryName;
+        }
+
         const placeHolder: string = localize('selectRegistry', 'Select an Azure Container Registry');
-        context.registry = (await context.ui.showQuickPick(this.getPicks(context), { placeHolder })).data;
+        context.registry = (await context.ui.showQuickPick(this.getPicks(context, predictedRegistry), { placeHolder })).data;
     }
 
     public shouldPrompt(context: IContainerRegistryImageContext): boolean {
@@ -30,10 +39,23 @@ export class AcrListStep extends AzureWizardPromptStep<IContainerRegistryImageCo
         return undefined;
     }
 
-    public async getPicks(context: IContainerRegistryImageContext): Promise<IAzureQuickPickItem<Registry>[]> {
+    public async getPicks(context: IContainerRegistryImageContext, predictedRegistry?: string): Promise<IAzureQuickPickItem<Registry>[]> {
         const client: ContainerRegistryManagementClient = await createContainerRegistryManagementClient(context);
         const registries = await uiUtils.listAllIterator(client.registries.list());
-        return registries.map((r) => { return { label: nonNullProp(r, 'name'), data: r, description: r.loginServer } });
+        const registryPicks = registries.map((r) => { return { label: nonNullProp(r, 'name'), data: r, description: r.loginServer, suppressPersistence: !!predictedRegistry } });
+
+        // We should swap and do the registryPicks after this logic in case we can't find the predictedRegistry, that way suppressPersistence will be true when it needs to be....
+        if (predictedRegistry) {
+            const prIndex: number = registryPicks.findIndex((r) => r.data.loginServer === predictedRegistry);
+
+            if (prIndex !== -1) {
+                const predictedPick = registryPicks.splice(prIndex, 1)[0];
+                predictedPick.description += ' (previously used)';
+                registryPicks.unshift(predictedPick);
+            }
+        }
+
+        return registryPicks;
     }
 }
 

--- a/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrListStep.ts
@@ -6,7 +6,7 @@
 import type { ContainerRegistryManagementClient, Registry } from "@azure/arm-containerregistry";
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from "@microsoft/vscode-azext-utils";
-import { acrDomain, latestImage, quickStartImageName } from "../../../../constants";
+import { acrDomain, currentlyDeployed, quickStartImageName } from "../../../../constants";
 import type { ContainerAppModel } from "../../../../tree/ContainerAppItem";
 import { createContainerRegistryManagementClient } from "../../../../utils/azureClients";
 import { parseImageName } from "../../../../utils/imageNameUtils";
@@ -42,25 +42,25 @@ export class AcrListStep extends AzureWizardPromptStep<IContainerRegistryImageCo
         const { registryDomain, registryName, referenceImageName } = parseImageName(getLatestContainerAppImage(containerApp));
 
         // If the image is not the default quickstart image, then we can try to suggest a registry based on the latest Container App image
-        let predictedRegistry: string | undefined;
+        let suggestedRegistry: string | undefined;
         if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
-            predictedRegistry = registryName;
+            suggestedRegistry = registryName;
         }
 
-        // Does the predicted registry exist in the list of pulled registries?  If so, move it to the front of the list
-        const prIndex: number = registries.findIndex((r) => !!predictedRegistry && r.loginServer === predictedRegistry);
-        const prExists: boolean = prIndex !== -1;
+        // Does the suggested registry exist in the list of pulled registries?  If so, move it to the front of the list
+        const srIndex: number = registries.findIndex((r) => !!suggestedRegistry && r.loginServer === suggestedRegistry);
+        const srExists: boolean = srIndex !== -1;
 
-        if (prExists) {
-            const pr: Registry = registries.splice(prIndex, 1)[0];
-            registries.unshift(pr);
+        if (srExists) {
+            const sr: Registry = registries.splice(srIndex, 1)[0];
+            registries.unshift(sr);
         }
 
         // Preferring 'suppressPersistence: true' over 'priority: highest' to avoid the possibility of a double parenthesis appearing in the description
         return registries.map((r) => {
-            return !!predictedRegistry && r.loginServer === predictedRegistry ?
-                { label: nonNullProp(r, 'name'), data: r, description: `${r.loginServer} ${latestImage}`, suppressPersistence: true } :
-                { label: nonNullProp(r, 'name'), data: r, description: r.loginServer, suppressPersistence: prExists };
+            return !!suggestedRegistry && r.loginServer === suggestedRegistry ?
+                { label: nonNullProp(r, 'name'), data: r, description: `${r.loginServer} ${currentlyDeployed}`, suppressPersistence: true } :
+                { label: nonNullProp(r, 'name'), data: r, description: r.loginServer, suppressPersistence: srExists };
         });
     }
 }

--- a/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
@@ -19,11 +19,11 @@ export class AcrRepositoriesListStep extends RegistryRepositoriesListStepBase {
         const repositoryNames: string[] = await uiUtils.listAllIterator(client.listRepositoryNames());
 
         const containerApp: ContainerAppModel = nonNullProp(context, 'targetContainer');
-        const { registryDomain, repositoryName, referenceImageName } = parseImageName(getLatestContainerAppImage(containerApp));
+        const { registryDomain, repositoryName, imageNameReference } = parseImageName(getLatestContainerAppImage(containerApp));
 
         // If the image is not the default quickstart image, then we can try to suggest a repository based on the latest Container App image
         let suggestedRepository: string | undefined;
-        if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
+        if (registryDomain === acrDomain && imageNameReference !== quickStartImageName) {
             suggestedRepository = repositoryName;
         }
 

--- a/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
@@ -30,7 +30,6 @@ export class AcrRepositoriesListStep extends RegistryRepositoriesListStepBase {
         // Does the suggested repositoryName exist in the list of pulled repositories?  If so, move it to the front of the list
         const srIndex: number = repositoryNames.findIndex((rn) => !!suggestedRepository && rn === suggestedRepository);
         const srExists: boolean = srIndex !== -1;
-
         if (srExists) {
             const sr: string = repositoryNames.splice(srIndex, 1)[0];
             repositoryNames.unshift(sr);

--- a/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { QuickPickItem } from "vscode";
-import { acrDomain, latestImage, quickStartImageName } from "../../../../constants";
+import { acrDomain, currentlyDeployed, quickStartImageName } from "../../../../constants";
 import type { ContainerAppModel } from "../../../../tree/ContainerAppItem";
 import { createContainerRegistryClient } from "../../../../utils/azureClients";
 import { parseImageName } from "../../../../utils/imageNameUtils";
@@ -22,25 +22,25 @@ export class AcrRepositoriesListStep extends RegistryRepositoriesListStepBase {
         const { registryDomain, repositoryName, referenceImageName } = parseImageName(getLatestContainerAppImage(containerApp));
 
         // If the image is not the default quickstart image, then we can try to suggest a repository based on the latest Container App image
-        let predictedRepository: string | undefined;
+        let suggestedRepository: string | undefined;
         if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
-            predictedRepository = repositoryName;
+            suggestedRepository = repositoryName;
         }
 
-        // Does the predicted repositoryName exist in the list of pulled repositories?  If so, move it to the front of the list
-        const prIndex: number = repositoryNames.findIndex((rn) => !!predictedRepository && rn === predictedRepository);
-        const prExists: boolean = prIndex !== -1;
+        // Does the suggested repositoryName exist in the list of pulled repositories?  If so, move it to the front of the list
+        const srIndex: number = repositoryNames.findIndex((rn) => !!suggestedRepository && rn === suggestedRepository);
+        const srExists: boolean = srIndex !== -1;
 
-        if (prExists) {
-            const pr: string = repositoryNames.splice(prIndex, 1)[0];
-            repositoryNames.unshift(pr);
+        if (srExists) {
+            const sr: string = repositoryNames.splice(srIndex, 1)[0];
+            repositoryNames.unshift(sr);
         }
 
         // Preferring 'suppressPersistence: true' over 'priority: highest' to avoid the possibility of a double parenthesis appearing in the description
         return repositoryNames.map((rn) => {
-            return !!predictedRepository && rn === predictedRepository ?
-                { label: rn, description: latestImage, suppressPersistence: true } :
-                { label: rn, suppressPersistence: prExists };
+            return !!suggestedRepository && rn === suggestedRepository ?
+                { label: rn, description: currentlyDeployed, suppressPersistence: true } :
+                { label: rn, suppressPersistence: srExists };
         });
     }
 }

--- a/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
+++ b/src/commands/imageSource/containerRegistry/acr/AcrRepositoriesListStep.ts
@@ -4,16 +4,43 @@
  *--------------------------------------------------------------------------------------------*/
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { QuickPickItem } from "vscode";
+import { acrDomain, latestImage, quickStartImageName } from "../../../../constants";
+import type { ContainerAppModel } from "../../../../tree/ContainerAppItem";
 import { createContainerRegistryClient } from "../../../../utils/azureClients";
-import { nonNullValue } from "../../../../utils/nonNull";
+import { parseImageName } from "../../../../utils/imageNameUtils";
+import { nonNullProp, nonNullValue } from "../../../../utils/nonNull";
 import { IContainerRegistryImageContext } from "../IContainerRegistryImageContext";
 import { RegistryRepositoriesListStepBase } from "../RegistryRepositoriesListBaseStep";
+import { getLatestContainerAppImage } from "../getLatestContainerImage";
 
 export class AcrRepositoriesListStep extends RegistryRepositoriesListStepBase {
     public async getPicks(context: IContainerRegistryImageContext): Promise<QuickPickItem[]> {
         const client = createContainerRegistryClient(context, nonNullValue(context.registry));
         const repositoryNames: string[] = await uiUtils.listAllIterator(client.listRepositoryNames());
 
-        return repositoryNames.map((rn) => { return { label: rn } });
+        const containerApp: ContainerAppModel = nonNullProp(context, 'targetContainer');
+        const { registryDomain, repositoryName, referenceImageName } = parseImageName(getLatestContainerAppImage(containerApp));
+
+        // If the image is not the default quickstart image, then we can try to suggest a repository based on the latest Container App image
+        let predictedRepository: string | undefined;
+        if (registryDomain === acrDomain && referenceImageName !== quickStartImageName) {
+            predictedRepository = repositoryName;
+        }
+
+        // Does the predicted repositoryName exist in the list of pulled repositories?  If so, move it to the front of the list
+        const prIndex: number = repositoryNames.findIndex((rn) => !!predictedRepository && rn === predictedRepository);
+        const prExists: boolean = prIndex !== -1;
+
+        if (prExists) {
+            const pr: string = repositoryNames.splice(prIndex, 1)[0];
+            repositoryNames.unshift(pr);
+        }
+
+        // Preferring 'suppressPersistence: true' over 'priority: highest' to avoid the possibility of a double parenthesis appearing in the description
+        return repositoryNames.map((rn) => {
+            return !!predictedRepository && rn === predictedRepository ?
+                { label: rn, description: latestImage, suppressPersistence: true } :
+                { label: rn, suppressPersistence: prExists };
+        });
     }
 }

--- a/src/commands/imageSource/containerRegistry/getLatestContainerImage.ts
+++ b/src/commands/imageSource/containerRegistry/getLatestContainerImage.ts
@@ -6,6 +6,6 @@
 import type { ContainerApp } from "@azure/arm-appcontainers";
 
 export function getLatestContainerAppImage(containerApp: ContainerApp): string | undefined {
-    // Currently only support single container
+    // We are currently only supporting one active container image per app
     return containerApp.template?.containers?.[0]?.image;
 }

--- a/src/commands/imageSource/containerRegistry/getLatestContainerImage.ts
+++ b/src/commands/imageSource/containerRegistry/getLatestContainerImage.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ContainerApp } from "@azure/arm-appcontainers";
+
+export function getLatestContainerAppImage(containerApp: ContainerApp): string | undefined {
+    // Currently only support single container
+    return containerApp.template?.containers?.[0]?.image;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,7 @@ export type ImageSourceValues = typeof ImageSource[keyof typeof ImageSource];
 export const acrDomain = 'azurecr.io';
 export const dockerHubDomain = 'docker.io';
 export const dockerHubRegistry = 'index.docker.io';
+export const quickStartImageName = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest';
 
 export type SupportedRegistries = 'azurecr.io' | 'docker.io';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ export namespace RevisionConstants {
     export const single: IAzureQuickPickItem<string> = { label: localize('single', 'Single'), description: localize('singleDesc', 'One active revision at a time'), data: 'single' };
 }
 
-export const latestImage: string = localize('latestImage', '(latest image)');
+export const currentlyDeployed: string = localize('currentlyDeployed', '(currently deployed)');
 
 export enum ScaleRuleTypes {
     HTTP = "HTTP scaling",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,8 @@ export namespace RevisionConstants {
     export const single: IAzureQuickPickItem<string> = { label: localize('single', 'Single'), description: localize('singleDesc', 'One active revision at a time'), data: 'single' };
 }
 
+export const latestImage: string = localize('latestImage', '(latest image)');
+
 export enum ScaleRuleTypes {
     HTTP = "HTTP scaling",
     Queue = "Azure queue"

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -31,7 +31,7 @@ interface ParsedImageName {
  * (2) 'registryDomain': The 'SupportedRegistries' domain, if it can be determined from the 'registryName';
  * (3) 'registryName': Everything before the first slash;
  * (4) 'namespace': Everything between the 'registryName' and the 'repositoryName', including intermediate slashes;
- * (5) 'repositoryName': Everything after the last slash (until the tag);
+ * (5) 'repositoryName': Everything after the last slash (until the tag, if it is present);
  * (6) 'tag': Everything after the ":", if it is present
  */
 export function parseImageName(imageName?: string): ParsedImageName {

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -14,22 +14,37 @@ interface ParsedImageName {
     registryDomain?: string;
     registryName?: string;
     namespace?: string;
-    image?: string;
+    repositoryName?: string;
     tag?: string;
 }
 
+/**
+ * @param imageName The full image name, including any registry, namespace, repository, and tag
+ *
+ * @example The following are some valid examples of a full image name:
+ * 'acrRegistryName.azurecr.io/repositoryName:tagName'
+ * 'docker.io/[...namespace]/repositoryName:tagName'
+ *
+ * @returns A 'ParsedImageName' with the following properties:
+ * (1) 'referenceImageName': The original full image name;
+ * (2) 'registryDomain': The 'SupportedRegistries' domain, if it can be determined from the 'registryName';
+ * (3) 'registryName': Everything before the first slash;
+ * (4) 'namespace': Everything between the 'registryName' and the 'repositoryName', including intermediate slashes;
+ * (5) 'repositoryName': Everything after the last slash (until the tag);
+ * (6) 'tag': Everything after the ":", if it is present
+ */
 export function parseImageName(imageName?: string): ParsedImageName {
     if (!imageName) {
         return {};
     }
 
-    const match: RegExpMatchArray | null = imageName.match(/^(?:(?<registryName>[^/]+)\/)?(?:(?<namespace>[^/]+)\/)?(?<image>[^/:]+)(?::(?<tag>[^/]+))?$/);
+    const match: RegExpMatchArray | null = imageName.match(/^(?:(?<registryName>[^/]+)\/)?(?:(?<namespace>[^/]+(?:\/[^/]+)*)\/)?(?<repositoryName>[^/:]+)(?::(?<tag>[^/]+))?$/);
     return {
         referenceImageName: imageName,
         registryDomain: match?.groups?.registryName ? detectRegistryDomain(match.groups.registryName) : undefined,
         registryName: match?.groups?.registryName,
         namespace: match?.groups?.namespace,
-        image: match?.groups?.image,
+        repositoryName: match?.groups?.repositoryName,
         tag: match?.groups?.tag
     };
 }

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -6,8 +6,33 @@
 import type { ContainerRegistryManagementClient, Registry } from "@azure/arm-containerregistry";
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
-import { acrDomain, dockerHubDomain, SupportedRegistries } from "../constants";
+import { SupportedRegistries, acrDomain, dockerHubDomain } from "../constants";
 import { createContainerRegistryManagementClient } from "./azureClients";
+
+interface ParsedImageName {
+    referenceImageName?: string;
+    registryDomain?: string;
+    registryName?: string;
+    namespace?: string;
+    image?: string;
+    tag?: string;
+}
+
+export function parseImageName(imageName?: string): ParsedImageName {
+    if (!imageName) {
+        return {};
+    }
+
+    const match: RegExpMatchArray | null = imageName.match(/^(?:(?<registryName>[^/]+)\/)?(?:(?<namespace>[^/]+)\/)?(?<image>[^/:]+)(?::(?<tag>[^/]+))?$/);
+    return {
+        referenceImageName: imageName,
+        registryDomain: match?.groups?.registryName ? detectRegistryDomain(match.groups.registryName) : undefined,
+        registryName: match?.groups?.registryName,
+        namespace: match?.groups?.namespace,
+        image: match?.groups?.image,
+        tag: match?.groups?.tag
+    };
+}
 
 /**
  * @param registryName When parsed from a full image name, everything before the first slash

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -22,9 +22,9 @@ interface ParsedImageName {
  * @param imageName The full image name, including any registry, namespace, repository, and tag
  *
  * @example
- * Format: '<registryName>/<...namespaces>/<repositoryName>:<tagName>'
- * ACR: 'acrRegistryName.azurecr.io/repositoryName:tagName'
- * DH: 'docker.io/namespace/repositoryName:tagName'
+ * Format: '<registryName>/<...namespaces>/<repositoryName>:<tag>'
+ * ACR: 'acrRegistryName.azurecr.io/repositoryName:tag'
+ * DH: 'docker.io/namespace/repositoryName:tag'
  *
  * @returns A 'ParsedImageName' with the following properties:
  * (1) 'referenceImageName': The original full image name;

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -21,9 +21,10 @@ interface ParsedImageName {
 /**
  * @param imageName The full image name, including any registry, namespace, repository, and tag
  *
- * @example The following are some valid examples of a full image name:
- * 'acrRegistryName.azurecr.io/repositoryName:tagName'
- * 'docker.io/[...namespace]/repositoryName:tagName'
+ * @example
+ * Format: '<registryName>/<...namespaces>/<repositoryName>:<tagName>'
+ * ACR: 'acrRegistryName.azurecr.io/repositoryName:tagName'
+ * DH: 'docker.io/namespace/repositoryName:tagName'
  *
  * @returns A 'ParsedImageName' with the following properties:
  * (1) 'referenceImageName': The original full image name;

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -11,7 +11,7 @@ import { createContainerRegistryManagementClient } from "./azureClients";
 
 interface ParsedImageName {
     referenceImageName?: string;
-    registryDomain?: string;
+    registryDomain?: SupportedRegistries;
     registryName?: string;
     namespace?: string;
     repositoryName?: string;

--- a/src/utils/imageNameUtils.ts
+++ b/src/utils/imageNameUtils.ts
@@ -10,7 +10,7 @@ import { SupportedRegistries, acrDomain, dockerHubDomain } from "../constants";
 import { createContainerRegistryManagementClient } from "./azureClients";
 
 interface ParsedImageName {
-    referenceImageName?: string;
+    imageNameReference?: string;
     registryDomain?: SupportedRegistries;
     registryName?: string;
     namespace?: string;
@@ -27,7 +27,7 @@ interface ParsedImageName {
  * DH: 'docker.io/namespace/repositoryName:tag'
  *
  * @returns A 'ParsedImageName' with the following properties:
- * (1) 'referenceImageName': The original full image name;
+ * (1) 'imageNameReference': The original full image name;
  * (2) 'registryDomain': The 'SupportedRegistries' domain, if it can be determined from the 'registryName';
  * (3) 'registryName': Everything before the first slash;
  * (4) 'namespace': Everything between the 'registryName' and the 'repositoryName', including intermediate slashes;
@@ -41,7 +41,7 @@ export function parseImageName(imageName?: string): ParsedImageName {
 
     const match: RegExpMatchArray | null = imageName.match(/^(?:(?<registryName>[^/]+)\/)?(?:(?<namespace>[^/]+(?:\/[^/]+)*)\/)?(?<repositoryName>[^/:]+)(?::(?<tag>[^/]+))?$/);
     return {
-        referenceImageName: imageName,
+        imageNameReference: imageName,
         registryDomain: match?.groups?.registryName ? detectRegistryDomain(match.groups.registryName) : undefined,
         registryName: match?.groups?.registryName,
         namespace: match?.groups?.namespace,


### PR DESCRIPTION
Partially addresses: #304 

Will add a separate PR to address third party registry steps like those associated with Docker Hub.

For this PR, the implementation I've added looks at the current container app image and checks to see if the values can be re-applied for the new deployment.  If it can, it will suggest the value by extracting it and placing it at the top of the list of quick picks and add the description: `(currently deployed)`.  (I'm very open to whatever labels you guys prefer instead.. I am not great with names/descriptions 😅)

Example:

![image](https://user-images.githubusercontent.com/40250218/228096911-4a5d5a04-e30f-484a-9ec7-aab8a56d5bdd.png)

This is different that `(recently used)` in that it always uses the context of the current Container App rather than using your last pick choice.

If the suggested pick is not found, it will default to the old way of categorizing via `(recently used)`.


