### PR TITLE
Only add `Build from project remotely...` pick if on Desktop

### DIFF
--- a/src/commands/imageSource/ImageSourceListStep.ts
+++ b/src/commands/imageSource/ImageSourceListStep.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from "@microsoft/vscode-azext-utils";
+import { UIKind, env, workspace } from "vscode";
 import { ImageSource, ImageSourceValues } from "../../constants";
 import { localize } from "../../utils/localize";
 import { setQuickStartImage } from "../createContainerApp/setQuickStartImage";
@@ -23,12 +24,16 @@ export class ImageSourceListStep extends AzureWizardPromptStep<IImageSourceBaseC
 
         const placeHolder: string = localize('imageBuildSourcePrompt', 'Select an image source for the container app');
         const picks: IAzureQuickPickItem<ImageSourceValues | undefined>[] = [
-            { label: imageSourceLabels[0], data: ImageSource.ContainerRegistry, suppressPersistence: true },
-            { label: imageSourceLabels[2], data: ImageSource.RemoteAcrBuild, suppressPersistence: true },
+            { label: imageSourceLabels[0], data: ImageSource.ContainerRegistry, suppressPersistence: true }
         ];
 
         if (context.showQuickStartImage) {
             picks.unshift({ label: imageSourceLabels[1], data: ImageSource.QuickStartImage, suppressPersistence: true });
+        }
+
+        const isVirtualWorkspace = workspace.workspaceFolders && workspace.workspaceFolders.every(f => f.uri.scheme !== 'file');
+        if (env.uiKind === UIKind.Desktop && !isVirtualWorkspace) {
+            picks.push({ label: imageSourceLabels[2], data: ImageSource.RemoteAcrBuild, suppressPersistence: true })
         }
 
         context.imageSource = (await context.ui.showQuickPick(picks, { placeHolder })).data;


### PR DESCRIPTION
We don't want this pick to show up when using .dev environment. I also tested it on virtual workspaces and that also seems to cause issues with the AcrRun so also not adding the pick when it is a virtual workspace. 

See [here](https://code.visualstudio.com/api/extension-guides/virtual-workspaces#detect-virtual-workspaces-programmatically) for details on detecting virtual workspaces. 