### PR TITLE
Remove unused try/finally

### DIFF
--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -66,12 +66,7 @@ export async function createContainerApp(context: IActionContext & Partial<ICrea
         localize('creatingContainerApp', 'Creating Container App "{0}"...', newContainerAppName),
         async () => {
             wizardContext.activityTitle = localize('createNamedContainerApp', 'Create Container App "{0}"', newContainerAppName);
-            try {
-                await wizard.execute();
-            } finally {
-                // refresh this node even if create fails because container app provision failure throws an error, but still creates a container app
-                // ext.state.notifyChildrenChanged(node.managedEnvironment.id);
-            }
+            await wizard.execute();
         });
 
     const createdContainerApp = nonNullProp(wizardContext, 'containerApp');


### PR DESCRIPTION
try/finally without catch blocks bubble up exceptions so this wasn't doing anything. The code in the finally block was originally commented out since `showCreatingChild` already emits a refresh event for the given id.