### PR TITLE
Add `showDeleting` method to `TreeItemState`

### DIFF
--- a/src/commands/deleteManagedEnvironment/deleteManagedEnvironment.ts
+++ b/src/commands/deleteManagedEnvironment/deleteManagedEnvironment.ts
@@ -44,8 +44,8 @@ export async function deleteManagedEnvironment(context: IActionContext & { suppr
         await wizard.prompt();
     }
 
-    await ext.state.runWithTemporaryDescription(managedEnvironment.id, localize('deleting', 'Deleting...'), async () => {
+    await ext.state.showDeleting(managedEnvironment.id, async () => {
         await wizard.execute();
-        ext.branchDataProvider.refresh();
     });
+    ext.branchDataProvider.refresh();
 }

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -140,7 +140,7 @@ export class ContainerAppItem implements ContainerAppsItem {
             await wizard.prompt();
         }
 
-        await ext.state.runWithTemporaryDescription(this.containerApp.id, localize('deleting', 'Deleting...'), async () => {
+        await ext.state.showDeleting(this.containerApp.id, async () => {
             await wizard.execute();
         });
         ext.state.notifyChildrenChanged(this.containerApp.managedEnvironmentId);


### PR DESCRIPTION
I'm cleaning up and fixing known bugs in `TreeItemState`. I'm preparing for it to be added to utils and shared between the extensions. Expect more follow-up PRs related to this stuff.

There was a super tiny bug when deleting a tree item where the "Deleting..." description would clear before the tree item was actually removed from the tree.

To fix this, we can simply avoid emitting an update event after we update the tree item state to remove the temporary description. That way the temporary description remains until the tree item is refreshed by someone/something else. In the case of delete, the children of the parent are refreshed, and the item is removed.

To do this, I added a `suppressRefresh` option to `TreeItemState#update`. As well as a `dontRefreshOnRemove` option to `TreeItemState.runWithTemporaryDescription`.

Since this option is a bit edge-casey, I added a helper method `TreeItemState.showDeleting` that wraps `TreeItemState.runWithTemporaryDescription` and passes the proper arguments for you.