### PR TITLE
Fix Dockerfile not showing when clicking "Browse..."

### DIFF
--- a/src/commands/imageSource/buildImageInAzure/DockerFileItemStep.ts
+++ b/src/commands/imageSource/buildImageInAzure/DockerFileItemStep.ts
@@ -11,7 +11,7 @@ import { IBuildImageInAzureContext } from "./IBuildImageInAzureContext";
 
 export class DockerFileItemStep extends AzureWizardPromptStep<IBuildImageInAzureContext> {
     public async prompt(context: IBuildImageInAzureContext): Promise<void> {
-        context.dockerFilePath = await selectWorkspaceFile(context, localize('dockerFilePick', 'Select a Dockerfile'), { filters: { 'Dockerfile': ['Dockerfile', 'Dockerfile.*'] } }, DOCKERFILE_GLOB_PATTERN);
+        context.dockerFilePath = await selectWorkspaceFile(context, localize('dockerFilePick', 'Select a Dockerfile'), { filters: {} }, DOCKERFILE_GLOB_PATTERN);
     }
 
     public shouldPrompt(context: IBuildImageInAzureContext): boolean {

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -26,5 +26,5 @@ export async function selectWorkspaceFile(context: IActionContext, placeHolder: 
         input = await context.ui.showQuickPick(quickPicks, { placeHolder });
     }
 
-    return input?.data || (await context.ui.showOpenDialog(options))[0].fsPath;
+    return input?.data || (await context.ui.showOpenDialog(options))[0].path;
 }


### PR DESCRIPTION
Fixes #296. 

Filtering was causing errors so just showing all file types now. 

Had to make a change in workspaceUtils since `selectWorkSpaceFile` returns an fsPath which causes errors. I checked to see if this caused issues with environment variables since `selectWorkSpaceFile` is used there but it seems to still be getting the data correctly. 