### PR TITLE
Revert "Don't hardcode ScaleItem collapsibleState"

### DIFF
--- a/src/tree/scaling/ScaleItem.ts
+++ b/src/tree/scaling/ScaleItem.ts
@@ -6,7 +6,7 @@
 import { Revision, Scale } from "@azure/arm-appcontainers";
 import { nonNullValue } from "@microsoft/vscode-azext-utils";
 import { AzureSubscription, ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
-import { ThemeIcon, TreeItem } from "vscode";
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { createGenericItem } from "../../utils/GenericItem";
 import { localize } from "../../utils/localize";
 import { treeUtils } from "../../utils/treeUtils";
@@ -42,6 +42,7 @@ export class ScaleItem implements ContainerAppsItem {
             label: localize('scaling', 'Scaling'),
             contextValue: 'scale',
             iconPath: treeUtils.getIconPath('02887-icon-menu-Container-Scale'),
+            collapsibleState: TreeItemCollapsibleState.Collapsed,
         }
     }
 


### PR DESCRIPTION
Reverts microsoft/vscode-azurecontainerapps#339

I totally blanked here, removing this tells VS Code that the item has no children.