### PR TITLE
Improve parameter type for `startStreamingLogs`

### DIFF
--- a/src/commands/logStream/startStreamingLogs.ts
+++ b/src/commands/logStream/startStreamingLogs.ts
@@ -14,12 +14,12 @@ import { ReplicaListStep } from "./ReplicaListStep";
 import { RevisionListStep } from "./RevisionListStep";
 import { logStreamRequest } from "./logStreamRequest";
 
-export async function startStreamingLogs(context: IActionContext, node?: ContainerAppItem): Promise<void> {
-    if (!node) {
-        node = await pickContainerApp(context);
+export async function startStreamingLogs(context: IActionContext, item?: Pick<ContainerAppItem, 'containerApp' | 'subscription'>): Promise<void> {
+    if (!item) {
+        item = await pickContainerApp(context);
     }
 
-    const { subscription, containerApp } = node;
+    const { subscription, containerApp } = item;
 
     const wizardContext: IStreamLogsContext = {
         ...context,


### PR DESCRIPTION
Based on feedback from Megan, this types-only change makes it possible to pass in only what the function needs and nothing more. In this case, you no longer need to pass an entire `ContainerAppItem`, only `subscription`, and `containerApp`.