### PR TITLE
Setup for GHAE Repository Inventory

### DIFF
--- a/.github/compliance/inventory.yml
+++ b/.github/compliance/inventory.yml
@@ -1,0 +1,4 @@
+inventory:
+  - source: ServiceTree
+    items:
+      - id: f509ef5c-b308-481f-8528-1e4d46e7b616


### PR DESCRIPTION
Testing this config in ACA first before adding to our other repositories...

As part of completing the `Asset Management` portion of our assessment this year, we are required to ensure our repositories are properly linked up through the Service Tree.  Our repositories weren't showing up in searches when I last checked with Jing and Misty who have admin privilege.  I reached out and was told that our repos need to have the below configuration to be properly registered:

https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/policy-service/ghae-repo-inventory