### PR TITLE
Add `ActionsTreeItem` to `Configurations`

### DIFF
--- a/src/tree/ConfigurationItem.ts
+++ b/src/tree/ConfigurationItem.ts
@@ -11,6 +11,7 @@ import { ContainerAppModel } from "./ContainerAppItem";
 import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataProvider";
 import { DaprEnabledItem, createDaprDisabledItem } from "./DaprItem";
 import { IngressDisabledItem, IngressItem } from "./IngressItem";
+import { ActionsTreeItem } from "./gitHub/ActionsTreeItem";
 
 export class ConfigurationItem implements ContainerAppsItem {
     id: string;
@@ -25,6 +26,7 @@ export class ConfigurationItem implements ContainerAppsItem {
             const children: TreeElementBase[] = [];
             children.push(this.containerApp.configuration?.ingress ? new IngressItem(this.subscription, this.containerApp) : new IngressDisabledItem(this.subscription, this.containerApp));
             children.push(this.containerApp.configuration?.dapr?.enabled ? new DaprEnabledItem(this.containerApp, this.containerApp.configuration.dapr) : createDaprDisabledItem(this.containerApp));
+            children.push(new ActionsTreeItem(this.subscription, this.containerApp));
             // We should add secrets/registries here when we support it
             return children;
         });

--- a/src/tree/gitHub/ActionsTreeItem.ts
+++ b/src/tree/gitHub/ActionsTreeItem.ts
@@ -49,6 +49,8 @@ export class ActionsTreeItem implements ContainerAppsItem {
                 branch: sourceControl.branch ?? 'main',
                 page: -1,
             };
+
+            context.errorHandling.suppressDisplay = true;
             return await getActions(context, actionWorkflowRunsParams);
         });
 


### PR DESCRIPTION
We lost the `ActionsTreeItem` when we swapped to the new UI.  I've added it back under the new `Configurations` node.

Also noticed that an error I thought was being completely swallowed was still being shown to the user, so I added a `suppressDisplay` to correct that behavior.