### PR TITLE
Reconfigure files and commands to fit the new revision management UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,22 +220,22 @@
                 },
                 {
                     "command": "containerApps.chooseRevisionMode",
-                    "when": "view == azureResourceGroups && (viewItem =~ /revisionItem(.*)revisionMode:single/i || viewItem =~ /revisionsItem/i)",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && (viewItem =~ /revisionItem(.*)revisionMode:single/i || viewItem =~ /revisionsItem/i)",
                     "group": "2@1"
                 },
                 {
                     "command": "containerApps.activateRevision",
-                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:inactive/i",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:inactive/i",
                     "group": "2@2"
                 },
                 {
                     "command": "containerApps.deactivateRevision",
-                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:active/i",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:active/i",
                     "group": "2@3"
                 },
                 {
                     "command": "containerApps.restartRevision",
-                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionState:active/i",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionItem(.*)revisionState:active/i",
                     "group": "2@4"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -220,23 +220,23 @@
                 },
                 {
                     "command": "containerApps.chooseRevisionMode",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionmode:single|revisions$/i",
-                    "group": "2@4"
-                },
-                {
-                    "command": "containerApps.activateRevision",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionmode:single|^inactive;revision[^a-z]/i",
+                    "when": "view == azureResourceGroups && (viewItem =~ /revisionItem(.*)revisionMode:single/i || viewItem =~ /revisionsItem/i)",
                     "group": "2@1"
                 },
                 {
-                    "command": "containerApps.deactivateRevision",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionmode:single|^active;revision[^a-z]/i",
+                    "command": "containerApps.activateRevision",
+                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:inactive/i",
                     "group": "2@2"
                 },
                 {
-                    "command": "containerApps.restartRevision",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /revisionmode:single|^active;revision[^a-z]/i",
+                    "command": "containerApps.deactivateRevision",
+                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionMode:multiple(.*)revisionState:active/i",
                     "group": "2@3"
+                },
+                {
+                    "command": "containerApps.restartRevision",
+                    "when": "view == azureResourceGroups && viewItem =~ /revisionItem(.*)revisionState:active/i",
+                    "group": "2@4"
                 },
                 {
                     "command": "containerApps.disableIngress",

--- a/resources/02889-icon-menu-Container-Revision-Management.svg
+++ b/resources/02889-icon-menu-Container-Revision-Management.svg
@@ -13,8 +13,8 @@
       <stop offset="1" stop-color="#a67af4" />
     </linearGradient>
     <linearGradient id="aef1cbb1-dedf-46f1-96c6-5b5ce0b6eb3c" x1="-35" y1="819.436" x2="-35" y2="825.838" gradientTransform="matrix(1, 0, 0, -1, 44, 838.016)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#32bedd" />
-      <stop offset="0.746" stop-color="#50e6ff" />
+      <stop offset="0" stop-color="#126e8d" />
+      <stop offset="0.746" stop-color="#32BEDD" />
     </linearGradient>
   </defs>
   <g id="a2629457-ce9e-4d73-ae91-6d52e8069297">

--- a/resources/02889-icon-menu-Container-Revision-Management.svg
+++ b/resources/02889-icon-menu-Container-Revision-Management.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <defs>
+    <linearGradient id="ba4ffed3-7262-453b-be7e-785b176dfa7a" x1="80.014" y1="684.098" x2="80.014" y2="699.918" gradientTransform="matrix(1, 0, 0, -1, -72, 701.516)" gradientUnits="userSpaceOnUse">
+      <stop offset="0.001" stop-color="#773adc" />
+      <stop offset="1" stop-color="#a67af4" />
+    </linearGradient>
+    <linearGradient id="e63b88a9-8187-4734-9dc8-d7591176790f" x1="7.84" y1="10.949" x2="11.38" y2="10.949" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff" stop-opacity="0.4" />
+      <stop offset="1" stop-color="#a67af4" />
+    </linearGradient>
+    <linearGradient id="b237bdbd-4125-45b9-ac9a-2502c780b4c1" x1="5.93" y1="7.915" x2="5.93" y2="14.09" gradientUnits="userSpaceOnUse">
+      <stop offset="0.135" stop-color="#fff" stop-opacity="0.6" />
+      <stop offset="1" stop-color="#a67af4" />
+    </linearGradient>
+    <linearGradient id="aef1cbb1-dedf-46f1-96c6-5b5ce0b6eb3c" x1="-35" y1="819.436" x2="-35" y2="825.838" gradientTransform="matrix(1, 0, 0, -1, 44, 838.016)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#32bedd" />
+      <stop offset="0.746" stop-color="#50e6ff" />
+    </linearGradient>
+  </defs>
+  <g id="a2629457-ce9e-4d73-ae91-6d52e8069297">
+    <path d="M14.244,6.688h-4.06a.915.915,0,0,1-.91-.92V1.728a.52.52,0,0,0-.35-.13H2.094a.538.538,0,0,0-.54.54v14.74a.538.538,0,0,0,.54.54h11.84a.536.536,0,0,0,.54-.53V7.128A.54.54,0,0,0,14.244,6.688Z" fill="url(#ba4ffed3-7262-453b-be7e-785b176dfa7a)" />
+    <path d="M16.471,5.53v9.758a.54.54,0,0,1-.54.54h-.778a.272.272,0,0,1-.272-.272V7.125a.94.94,0,0,0-.293-.683.238.238,0,0,0-.032-.038L9.564,1.428a.376.376,0,0,0-.136-.09.95.95,0,0,0-.505-.147H3.82A.272.272,0,0,1,3.548.919V.543A.54.54,0,0,1,4.087,0h6.834a.538.538,0,0,1,.353.135V.123L16.266,5.1h-.015A.536.536,0,0,1,16.471,5.53Zm-7.2-3.812v4.05a.915.915,0,0,0,.91.92h4.08Z" fill="#773adc" />
+    <path d="M11.42,9.059v3.565a.2.2,0,0,1-.122.187L7.75,14.276a.118.118,0,0,0,.046-.068.1.1,0,0,0,0-.025V7.73a.11.11,0,0,0-.085-.108l.01,0,3.564,1.244A.2.2,0,0,1,11.42,9.059Z" fill="url(#e63b88a9-8187-4734-9dc8-d7591176790f)" />
+    <path d="M7.8,7.73v6.453a.1.1,0,0,1,0,.025.118.118,0,0,1-.046.068.1.1,0,0,1-.056.015H7.669l-3.524-.772a.107.107,0,0,1-.084-.107V8.394a.11.11,0,0,1,.086-.109l3.525-.664h.021l.021,0A.11.11,0,0,1,7.8,7.73Z" fill="url(#b237bdbd-4125-45b9-ac9a-2502c780b4c1)" />
+    <path d="M7.269,8.4V13.5L6.043,13.29V8.621Zm-2.732.473v4.091l1.067.224v-4.5Z" fill="#fff" opacity="0.6" />
+    <rect y="11.605" width="18" height="6.391" rx="0.598" fill="url(#aef1cbb1-dedf-46f1-96c6-5b5ce0b6eb3c)" />
+    <rect x="6.445" y="13.184" width="5.132" height="0.928" rx="0.459" fill="#f2f2f2" />
+  </g>
+</svg>

--- a/src/commands/ingress/editTargetPort/editTargetPort.ts
+++ b/src/commands/ingress/editTargetPort/editTargetPort.ts
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createSubscriptionContext, IActionContext } from "@microsoft/vscode-azext-utils";
+import { IngressItem } from "../../../tree/configurations/IngressItem";
 import type { ContainerAppItem } from "../../../tree/ContainerAppItem";
-import { IngressItem } from "../../../tree/IngressItem";
 import { createActivityContext } from "../../../utils/activityUtils";
 import { localize } from "../../../utils/localize";
 import { pickContainerApp } from "../../../utils/pickContainerApp";

--- a/src/commands/ingress/toggleIngressVisibility/toggleIngressVisibility.ts
+++ b/src/commands/ingress/toggleIngressVisibility/toggleIngressVisibility.ts
@@ -2,7 +2,7 @@ import type { Ingress } from "@azure/arm-appcontainers";
 import { AzureWizard, AzureWizardExecuteStep, IActionContext, createSubscriptionContext, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { IngressConstants } from "../../../constants";
 import type { ContainerAppItem } from "../../../tree/ContainerAppItem";
-import type { IngressItem } from "../../../tree/IngressItem";
+import type { IngressItem } from "../../../tree/configurations/IngressItem";
 import { createActivityContext } from "../../../utils/activityUtils";
 import { localize } from "../../../utils/localize";
 import { pickContainerApp } from "../../../utils/pickContainerApp";

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -5,7 +5,6 @@
 
 import { registerCommandWithTreeNodeUnwrapping, registerErrorHandler, registerReportIssueCommand } from '@microsoft/vscode-azext-utils';
 import { browseContainerAppNode } from './browseContainerApp';
-import { chooseRevisionMode } from './chooseRevisionMode';
 import { createContainerApp } from './createContainerApp/createContainerApp';
 import { createManagedEnvironment } from './createManagedEnvironment/createManagedEnvironment';
 import { deleteContainerApp } from './deleteContainerApp/deleteContainerApp';
@@ -22,9 +21,10 @@ import { toggleIngressVisibility } from './ingress/toggleIngressVisibility/toggl
 import { startStreamingLogs } from './logStream/startStreamingLogs';
 import { stopStreamingLogs } from './logStream/stopStreamingLogs';
 import { openConsoleInPortal } from './openConsoleInPortal';
-import { activateRevision } from './revisionCommands/activateRevision';
-import { deactivateRevision } from './revisionCommands/deactivateRevision';
-import { restartRevision } from './revisionCommands/restartRevision';
+import { activateRevision } from './revision/activateRevision';
+import { chooseRevisionMode } from './revision/chooseRevisionMode';
+import { deactivateRevision } from './revision/deactivateRevision';
+import { restartRevision } from './revision/restartRevision';
 import { addScaleRule } from './scaling/addScaleRule/addScaleRule';
 import { editScalingRange } from './scaling/editScalingRange';
 

--- a/src/commands/revision/activateRevision.ts
+++ b/src/commands/revision/activateRevision.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ContainerAppItem } from "../../tree/ContainerAppItem";
-import { RevisionItem } from "../../tree/RevisionItem";
+import type { IActionContext } from "@microsoft/vscode-azext-utils";
+import type { RevisionItem } from "../../tree/revisionManagement/RevisionItem";
 import { executeRevisionOperation } from "./changeRevisionActiveState";
 
-export function deactivateRevision(context: IActionContext, node?: ContainerAppItem | RevisionItem): Promise<void> {
-    return executeRevisionOperation(context, node, 'deactivateRevision');
+export function activateRevision(context: IActionContext, node?: RevisionItem): Promise<void> {
+    return executeRevisionOperation(context, node, 'activateRevision');
 }

--- a/src/commands/revision/changeRevisionActiveState.ts
+++ b/src/commands/revision/changeRevisionActiveState.ts
@@ -6,13 +6,12 @@
 import { ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { ContainerAppItem } from "../../tree/ContainerAppItem";
-import { RevisionItem } from "../../tree/RevisionItem";
+import { RevisionItem } from "../../tree/revisionManagement/RevisionItem";
 import { createContainerAppsClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
 import { pickContainerApp } from "../../utils/pickContainerApp";
 
-export async function executeRevisionOperation(context: IActionContext, node: ContainerAppItem | RevisionItem | undefined, operation: RevisionOperation): Promise<void> {
+export async function executeRevisionOperation(context: IActionContext, node: RevisionItem | undefined, operation: RevisionOperation): Promise<void> {
     const item = node ?? await pickContainerApp(context);
 
     await ext.state.runWithTemporaryDescription(item.id, revisionOperationDescriptions[operation], async () => {

--- a/src/commands/revision/chooseRevisionMode.ts
+++ b/src/commands/revision/chooseRevisionMode.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KnownActiveRevisionsMode } from "@azure/arm-appcontainers";
-import { IActionContext, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
+import type { IActionContext, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";
-import { ext } from "../extensionVariables";
-import { ContainerAppModel } from "../tree/ContainerAppItem";
-import { ContainerAppsItem } from "../tree/ContainerAppsBranchDataProvider";
-import { localize } from "../utils/localize";
-import { pickContainerApp } from "../utils/pickContainerApp";
-import { updateContainerApp } from "./deployContainerApp/updateContainerApp";
+import { ext } from "../../extensionVariables";
+import type { ContainerAppModel } from "../../tree/ContainerAppItem";
+import type { RevisionsItem } from "../../tree/revisionManagement/RevisionsItem";
+import { localize } from "../../utils/localize";
+import { pickContainerApp } from "../../utils/pickContainerApp";
+import { updateContainerApp } from "../deployContainerApp/updateContainerApp";
 
-export async function chooseRevisionMode(context: IActionContext, node?: ContainerAppsItem): Promise<void> {
+export async function chooseRevisionMode(context: IActionContext, node?: RevisionsItem): Promise<void> {
     const { subscription, containerApp } = node ?? await pickContainerApp(context);
 
     const pickedRevisionMode = await pickRevisionsMode(context, containerApp);

--- a/src/commands/revision/deactivateRevision.ts
+++ b/src/commands/revision/deactivateRevision.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ContainerAppItem } from "../../tree/ContainerAppItem";
-import { RevisionItem } from "../../tree/RevisionItem";
+import { RevisionItem } from "../../tree/revisionManagement/RevisionItem";
 import { executeRevisionOperation } from "./changeRevisionActiveState";
 
-export function activateRevision(context: IActionContext, node?: ContainerAppItem | RevisionItem): Promise<void> {
-    return executeRevisionOperation(context, node, 'activateRevision');
+export function deactivateRevision(context: IActionContext, node?: RevisionItem): Promise<void> {
+    return executeRevisionOperation(context, node, 'deactivateRevision');
 }

--- a/src/commands/revision/restartRevision.ts
+++ b/src/commands/revision/restartRevision.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ContainerAppItem } from "../../tree/ContainerAppItem";
-import { RevisionItem } from "../../tree/RevisionItem";
+import { RevisionItem } from "../../tree/revisionManagement/RevisionItem";
 import { executeRevisionOperation } from "./changeRevisionActiveState";
 
-export function restartRevision(context: IActionContext, node?: ContainerAppItem | RevisionItem): Promise<void> {
+export function restartRevision(context: IActionContext, node?: RevisionItem): Promise<void> {
     return executeRevisionOperation(context, node, 'restartRevision');
 }

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -16,11 +16,11 @@ import { createContainerAppsAPIClient, createContainerAppsClient } from "../util
 import { createPortalUrl } from "../utils/createPortalUrl";
 import { localize } from "../utils/localize";
 import { treeUtils } from "../utils/treeUtils";
-import { ConfigurationItem } from "./ConfigurationItem";
 import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataProvider";
 import { LogsItem } from "./LogsItem";
-import { RevisionItem } from "./RevisionItem";
-import { RevisionsItem } from "./RevisionsItem";
+import { ConfigurationItem } from "./configurations/ConfigurationItem";
+import { RevisionItem } from "./revisionManagement/RevisionItem";
+import { RevisionsItem } from "./revisionManagement/RevisionsItem";
 
 export interface ContainerAppModel extends ContainerApp {
     id: string;

--- a/src/tree/configurations/ConfigurationItem.ts
+++ b/src/tree/configurations/ConfigurationItem.ts
@@ -3,15 +3,17 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandling } from "@microsoft/vscode-azext-utils";
-import { AzureSubscription } from "@microsoft/vscode-azureresources-api";
+import { callWithTelemetryAndErrorHandling, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { AzureSubscription, ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
-import { localize } from "../utils/localize";
-import { ContainerAppModel } from "./ContainerAppItem";
-import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataProvider";
+import { localize } from "../../utils/localize";
+import { ContainerAppModel } from "../ContainerAppItem";
+import { ContainerAppsItem, TreeElementBase } from "../ContainerAppsBranchDataProvider";
+import { ActionsTreeItem } from "../gitHub/ActionsTreeItem";
 import { DaprEnabledItem, createDaprDisabledItem } from "./DaprItem";
 import { IngressDisabledItem, IngressItem } from "./IngressItem";
-import { ActionsTreeItem } from "./gitHub/ActionsTreeItem";
+
+const configuration: string = localize('configuration', 'Configuration');
 
 export class ConfigurationItem implements ContainerAppsItem {
     id: string;
@@ -19,6 +21,11 @@ export class ConfigurationItem implements ContainerAppsItem {
     // this is called "Settings" in the Portal
     constructor(public readonly subscription: AzureSubscription, public readonly containerApp: ContainerAppModel) {
         this.id = `${containerApp.id}/Configurations`;
+    }
+
+    viewProperties: ViewPropertiesModel = {
+        data: nonNullProp(this.containerApp, 'configuration'),
+        label: `${this.containerApp.name} ${configuration}`,
     }
 
     async getChildren(): Promise<TreeElementBase[]> {

--- a/src/tree/configurations/DaprItem.ts
+++ b/src/tree/configurations/DaprItem.ts
@@ -7,10 +7,10 @@ import { ContainerApp, Dapr } from "@azure/arm-appcontainers";
 import { createGenericElement } from "@microsoft/vscode-azext-utils";
 import { ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
-import { localize } from "../utils/localize";
-import { treeUtils } from "../utils/treeUtils";
-import { ContainerAppModel } from "./ContainerAppItem";
-import { TreeElementBase } from "./ContainerAppsBranchDataProvider";
+import { localize } from "../../utils/localize";
+import { treeUtils } from "../../utils/treeUtils";
+import { ContainerAppModel } from "../ContainerAppItem";
+import { TreeElementBase } from "../ContainerAppsBranchDataProvider";
 
 export class DaprEnabledItem implements TreeElementBase {
 

--- a/src/tree/configurations/IngressItem.ts
+++ b/src/tree/configurations/IngressItem.ts
@@ -7,11 +7,11 @@ import { ContainerApp, Ingress } from "@azure/arm-appcontainers";
 import { createGenericElement } from "@microsoft/vscode-azext-utils";
 import { AzureSubscription, ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
-import { IngressConstants, azResourceContextValue } from "../constants";
-import { localize } from "../utils/localize";
-import { treeUtils } from "../utils/treeUtils";
-import { ContainerAppModel } from "./ContainerAppItem";
-import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataProvider";
+import { IngressConstants, azResourceContextValue } from "../../constants";
+import { localize } from "../../utils/localize";
+import { treeUtils } from "../../utils/treeUtils";
+import { ContainerAppModel } from "../ContainerAppItem";
+import { ContainerAppsItem, TreeElementBase } from "../ContainerAppsBranchDataProvider";
 
 const label: string = localize('ingress', 'Ingress');
 

--- a/src/tree/revisionManagement/RevisionsItem.ts
+++ b/src/tree/revisionManagement/RevisionsItem.ts
@@ -4,21 +4,30 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { uiUtils } from "@microsoft/vscode-azext-azureutils";
-import { callWithTelemetryAndErrorHandling, createSubscriptionContext } from "@microsoft/vscode-azext-utils";
-import { AzureSubscription } from "@microsoft/vscode-azureresources-api";
+import { TreeElementBase, callWithTelemetryAndErrorHandling, createContextValue, createSubscriptionContext } from "@microsoft/vscode-azext-utils";
+import type { AzureSubscription } from "@microsoft/vscode-azureresources-api";
 import { TreeItem, TreeItemCollapsibleState } from "vscode";
-import { createContainerAppsAPIClient } from "../utils/azureClients";
-import { localize } from "../utils/localize";
-import { treeUtils } from "../utils/treeUtils";
-import { ContainerAppModel } from "./ContainerAppItem";
-import { ContainerAppsItem, TreeElementBase } from "./ContainerAppsBranchDataProvider";
+import { createContainerAppsAPIClient } from "../../utils/azureClients";
+import { localize } from "../../utils/localize";
+import { treeUtils } from "../../utils/treeUtils";
+import type { ContainerAppModel } from "../ContainerAppItem";
+import type { ContainerAppsItem } from "../ContainerAppsBranchDataProvider";
 import { RevisionItem } from "./RevisionItem";
 
 export class RevisionsItem implements ContainerAppsItem {
+    static contextValue: string = 'revisionsItem';
+    static contextValueRegExp: RegExp = new RegExp(RevisionsItem.contextValue);
+
     id: string;
 
     constructor(public readonly subscription: AzureSubscription, public readonly containerApp: ContainerAppModel) {
         this.id = `${containerApp.id}/Revisions`;
+    }
+
+    get contextValue(): string {
+        const values: string[] = [RevisionsItem.contextValue];
+        // values.push(ext.revisionDraftFileSystem.doesContainerAppsItemHaveRevisionDraft(this) ? 'revisionDraft:true' : 'revisionDraft:false');
+        return createContextValue(values);
     }
 
     async getChildren(): Promise<TreeElementBase[]> {
@@ -26,7 +35,6 @@ export class RevisionsItem implements ContainerAppsItem {
             const client = await createContainerAppsAPIClient([context, createSubscriptionContext(this.subscription)]);
             const revisions = await uiUtils.listAllIterator(client.containerAppsRevisions.listRevisions(this.containerApp.resourceGroup, this.containerApp.name));
             return revisions.map(revision => new RevisionItem(this.subscription, this.containerApp, revision));
-
         });
 
         return result?.reverse() ?? [];
@@ -35,9 +43,9 @@ export class RevisionsItem implements ContainerAppsItem {
     getTreeItem(): TreeItem {
         return {
             label: localize('revisions', 'Revision Management'),
-            iconPath: treeUtils.getIconPath('02885-icon-menu-Container-Revision-Active'),
-            contextValue: 'revisions',
+            iconPath: treeUtils.getIconPath('02889-icon-menu-Container-Revision-Management'),
+            contextValue: this.contextValue,
             collapsibleState: TreeItemCollapsibleState.Collapsed,
-        }
+        };
     }
 }

--- a/src/tree/scaling/ScaleRuleGroupItem.ts
+++ b/src/tree/scaling/ScaleRuleGroupItem.ts
@@ -9,7 +9,7 @@ import { AzureSubscription } from "@microsoft/vscode-azureresources-api";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import { localize } from "../../utils/localize";
 import { ContainerAppModel } from "../ContainerAppItem";
-import { RevisionsItemModel } from "../RevisionItem";
+import { RevisionsItemModel } from "../revisionManagement/RevisionItem";
 import { createScaleRuleItem } from "./ScaleRuleItem";
 
 export interface ScaleRuleGroupItem extends RevisionsItemModel {


### PR DESCRIPTION
Builds on top of this work: #379 

Closes #380 

Summary of work:

- Reorganized some files
- Moved some of the revision commands off of the `ContainerAppItem` to the `RevisionItem` and `RevisionsItem`
- Renamed/restructured revision context values
- Add view properties to the newer `ConfigurationItem`
- Add new `Revision Management` icon
- Some minor related prep work for the upcoming revision draft PRs