### PR TITLE
Update secret name validation to not allow `.`

### DIFF
--- a/src/commands/secret/addSecret/SecretNameStep.ts
+++ b/src/commands/secret/addSecret/SecretNameStep.ts
@@ -29,9 +29,8 @@ export class SecretNameStep extends AzureWizardPromptStep<ISecretContext> {
             return validateUtils.getInvalidLengthMessage();
         }
 
-        const allowedSymbols: string = '-.';
-        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value, allowedSymbols)) {
-            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage(allowedSymbols);
+        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value)) {
+            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage();
         }
 
         const secrets: Secret[] = context.containerApp?.configuration?.secrets ?? [];


### PR DESCRIPTION
Closes #421 

Remove the `.` symbol and just use the default (`-`).

Turns out the portal allows `.` but the service itself doesn't allow this.