### PR TITLE
Update arm-appcontainers package for new V2 environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@azure/arm-appcontainers": "^2.0.0-beta.1",
+                "@azure/arm-appcontainers": "^2.0.0-beta.3",
                 "@azure/arm-containerregistry": "^10.0.0",
                 "@azure/arm-operationalinsights": "^8.0.0",
                 "@azure/arm-resources": "^5.0.1",
@@ -78,14 +78,14 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/arm-appcontainers": {
-            "version": "2.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-2.0.0-beta.2.tgz",
-            "integrity": "sha512-lhkmvF5x7+MRDdd8EcDHZkJJRmDU6zztnvESUlupAN5pTLIahJj0hQZ3PXDYskK+kOHYxYkEEdbjgP29TZMN/g==",
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-2.0.0-beta.3.tgz",
+            "integrity": "sha512-ldh6Zgch7VKzk7tFqVSr0fG5P4CCytII6cnxckg6D4oiSFqrbknuwIH8QKqVYlxgim6qvTClvxMw4gT9LZ5Nfg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
@@ -11820,14 +11820,14 @@
             }
         },
         "@azure/arm-appcontainers": {
-            "version": "2.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-2.0.0-beta.2.tgz",
-            "integrity": "sha512-lhkmvF5x7+MRDdd8EcDHZkJJRmDU6zztnvESUlupAN5pTLIahJj0hQZ3PXDYskK+kOHYxYkEEdbjgP29TZMN/g==",
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appcontainers/-/arm-appcontainers-2.0.0-beta.3.tgz",
+            "integrity": "sha512-ldh6Zgch7VKzk7tFqVSr0fG5P4CCytII6cnxckg6D4oiSFqrbknuwIH8QKqVYlxgim6qvTClvxMw4gT9LZ5Nfg==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -504,7 +504,7 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@azure/arm-appcontainers": "^2.0.0-beta.1",
+        "@azure/arm-appcontainers": "^2.0.0-beta.3",
         "@azure/arm-containerregistry": "^10.0.0",
         "@azure/arm-operationalinsights": "^8.0.0",
         "@azure/arm-resources": "^5.0.1",


### PR DESCRIPTION
Fixes #429. 

Upgrading the package to the most recent beta version allowed new container apps to be created under the new V2 environments with no error. I also tested under the old type of environments and was still able to create, delete, update image, and change revision modes. 