### PR TITLE
Enforce new execute step priority ranges

### DIFF
--- a/src/commands/EXECUTE_PRIORITY.md
+++ b/src/commands/EXECUTE_PRIORITY.md
@@ -1,0 +1,115 @@
+# Execute Step Priority
+
+## I. Create, Update, or Deploy
+
+When creating or updating resources, execute steps should occupy certain priority ranges to ensure creation happens in the required sequential order.
+0 - 190 should be kept clear for Azure Tools common execute steps (e.g. VerifyProvidersStep, ResourceGroupCreateStep, etc.).
+
+### 1. Managed Environment
+
+<b>Priority Range</b>: 200 - 290
+
+#### Steps
+
+- LogAnalyticsCreateStep: 220
+- ManagedEnvironmentCreateStep: 250
+
+### 2. Azure Container Registry
+
+<b>Priority Range</b>: 300 - 390
+
+#### Steps
+
+- RegistryCreateStep: 350
+
+### 3. Image Source
+
+<b>Priority Range</b>: 400 - 490
+
+#### Build Image in Azure Steps
+
+- TarFileStep: 420
+- UploadSourceCodeStep: 430
+- RunStep: 440
+- BuildImageStep: 450
+- ContainerRegistryImageConfigureStep: 470
+- ContainerAppUpdateStep: 480 (temporary, only gets called when a container app already exists)
+
+#### Container Registry Steps
+
+- ContainerRegistryImageConfigureStep: 470
+- ContainerAppUpdateStep: 480 (temporary, only gets called when a container app already exists)
+
+### 4. Environment Variables
+
+<b>Priority Range</b>: 500 - 590
+
+#### Steps
+
+Reserved
+
+### 5. Ingress
+
+<b>Priority Range</b>: 600 - 690
+
+#### Steps
+
+- EnableIngressStep: 650
+- DisableIngressStep: 650
+
+- TargetPortUpdateStep: 650 (single command only)
+- ToggleIngressVisibilityStep: 650 (single command only)
+
+### 6. Container App
+
+<b>Priority Range</b>: 700 - 790
+
+#### Steps
+
+ContainerAppCreateStep: 750
+
+### 7. Secrets
+
+<b>Priority Range</b>: 800 - 890
+
+#### Steps
+
+SecretCreateStep: 820
+SecretDeleteStep: 850
+SecretUpdateStep: 850
+
+### 8. Unallocated Space
+
+<b>Priority Range</b>: 900 - 1090
+
+#### Steps
+
+Reserved for future commands TBD.
+
+### 9. Scaling
+
+<b>Priority Range</b>: 1100 - 1190
+
+#### Steps
+
+AddScaleRuleStep: 1120
+
+### 10. Unallocated Space
+
+<b>Priority Range</b>: 1200 - 1390
+
+#### Steps
+
+Reserved for future commands TBD.
+
+### 11. Deploy
+
+<b>Priority Range</b>: 1400 - 1490
+
+#### Steps
+
+DeployRevisionDraftStep: 1450
+
+## II. Delete Steps
+
+When deleting, resources typically the priority ranges will change as the dependencies are inverted when compared to the create steps.

--- a/src/commands/EXECUTE_PRIORITY.md
+++ b/src/commands/EXECUTE_PRIORITY.md
@@ -77,7 +77,6 @@ Reserved
 #### Steps
 
 - SecretCreateStep: 820
-- SecretDeleteStep: 850
 - SecretUpdateStep: 850
 
 ### 8. Unallocated Space

--- a/src/commands/EXECUTE_PRIORITY.md
+++ b/src/commands/EXECUTE_PRIORITY.md
@@ -113,4 +113,5 @@ Reserved
 
 ## II. Delete Steps
 
-When deleting, resources typically the priority ranges will change as the dependencies are inverted when compared to the create steps.
+TBD...
+Note: When deleting resources, typically the priority ranges will change as the dependencies are inverted when compared to the create steps.

--- a/src/commands/EXECUTE_PRIORITY.md
+++ b/src/commands/EXECUTE_PRIORITY.md
@@ -33,12 +33,11 @@ When creating or updating resources, execute steps should occupy certain priorit
 - RunStep: 440
 - BuildImageStep: 450
 - ContainerRegistryImageConfigureStep: 470
-- ContainerAppUpdateStep: 480 (temporary, only gets called when a container app already exists)
 
 #### Container Registry Steps
 
 - ContainerRegistryImageConfigureStep: 470
-- ContainerAppUpdateStep: 480 (temporary, only gets called when a container app already exists)
+- ContainerAppUpdateStep: 480 (Todo - investigate decoupling this command from imageSource when revision draft update support is added)
 
 ### 4. Environment Variables
 
@@ -66,7 +65,7 @@ Reserved
 
 #### Steps
 
-ContainerAppCreateStep: 750
+- ContainerAppCreateStep: 750
 
 ### 7. Secrets
 
@@ -74,9 +73,9 @@ ContainerAppCreateStep: 750
 
 #### Steps
 
-SecretCreateStep: 820
-SecretDeleteStep: 850
-SecretUpdateStep: 850
+- SecretCreateStep: 820
+- SecretDeleteStep: 850
+- SecretUpdateStep: 850
 
 ### 8. Unallocated Space
 
@@ -84,7 +83,7 @@ SecretUpdateStep: 850
 
 #### Steps
 
-Reserved for future commands TBD.
+- Reserved for future commands TBD.
 
 ### 9. Scaling
 
@@ -92,7 +91,7 @@ Reserved for future commands TBD.
 
 #### Steps
 
-AddScaleRuleStep: 1120
+- AddScaleRuleStep: 1120
 
 ### 10. Unallocated Space
 
@@ -100,7 +99,7 @@ AddScaleRuleStep: 1120
 
 #### Steps
 
-Reserved for future commands TBD.
+- Reserved for future commands TBD.
 
 ### 11. Deploy
 
@@ -108,7 +107,7 @@ Reserved for future commands TBD.
 
 #### Steps
 
-DeployRevisionDraftStep: 1450
+- DeployRevisionDraftStep: 1450
 
 ## II. Delete Steps
 

--- a/src/commands/EXECUTE_PRIORITY.md
+++ b/src/commands/EXECUTE_PRIORITY.md
@@ -37,6 +37,9 @@ When creating or updating resources, execute steps should occupy certain priorit
 #### Container Registry Steps
 
 - ContainerRegistryImageConfigureStep: 470
+
+#### Common Steps
+
 - ContainerAppUpdateStep: 480 (Todo - investigate decoupling this command from imageSource when revision draft update support is added)
 
 ### 4. Environment Variables

--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -16,7 +16,7 @@ import { getContainerNameForImage } from "../deployImage/imageSource/containerRe
 import { ICreateContainerAppContext } from "./ICreateContainerAppContext";
 
 export class ContainerAppCreateStep extends AzureWizardExecuteStep<ICreateContainerAppContext> {
-    public priority: number = 250;
+    public priority: number = 750;
 
     public async execute(context: ICreateContainerAppContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const appClient: ContainerAppsAPIClient = await createContainerAppsAPIClient(context);

--- a/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
+++ b/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
@@ -13,7 +13,7 @@ import { nonNullProp, nonNullValue } from "../../utils/nonNull";
 import { IManagedEnvironmentContext } from "./IManagedEnvironmentContext";
 
 export class LogAnalyticsCreateStep extends AzureWizardExecuteStep<IManagedEnvironmentContext> {
-    public priority: number = 200;
+    public priority: number = 220;
 
     public async execute(context: IManagedEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const opClient = await createOperationalInsightsManagementClient(context);

--- a/src/commands/deployImage/ContainerAppUpdateStep.ts
+++ b/src/commands/deployImage/ContainerAppUpdateStep.ts
@@ -14,7 +14,7 @@ import type { IDeployImageContext } from "./deployImage";
 import { getContainerNameForImage } from "./imageSource/containerRegistry/getContainerNameForImage";
 
 export class ContainerAppUpdateStep extends AzureWizardExecuteStep<IDeployImageContext> {
-    public priority: number = 260;
+    public priority: number = 480;
 
     public async execute(context: IDeployImageContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');

--- a/src/commands/deployImage/imageSource/buildImageInAzure/BuildImageStep.ts
+++ b/src/commands/deployImage/imageSource/buildImageInAzure/BuildImageStep.ts
@@ -12,7 +12,7 @@ import type { IBuildImageInAzureContext } from "./IBuildImageInAzureContext";
 import { buildImageInAzure } from "./buildImageInAzure";
 
 export class BuildImageStep extends AzureWizardExecuteStep<IBuildImageInAzureContext> {
-    public priority: number = 225;
+    public priority: number = 450;
 
     public async execute(context: IBuildImageInAzureContext): Promise<void> {
         context.registryDomain = acrDomain;

--- a/src/commands/deployImage/imageSource/buildImageInAzure/RunStep.ts
+++ b/src/commands/deployImage/imageSource/buildImageInAzure/RunStep.ts
@@ -11,7 +11,7 @@ import { localize } from "../../../../utils/localize";
 import type { IBuildImageInAzureContext } from "./IBuildImageInAzureContext";
 
 export class RunStep extends AzureWizardExecuteStep<IBuildImageInAzureContext> {
-    public priority: number = 200;
+    public priority: number = 440;
 
     public async execute(context: IBuildImageInAzureContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         try {

--- a/src/commands/deployImage/imageSource/buildImageInAzure/TarFileStep.ts
+++ b/src/commands/deployImage/imageSource/buildImageInAzure/TarFileStep.ts
@@ -11,7 +11,7 @@ import { IBuildImageInAzureContext } from "./IBuildImageInAzureContext";
 const idPrecision = 6;
 
 export class TarFileStep extends AzureWizardExecuteStep<IBuildImageInAzureContext> {
-    public priority: number = 150;
+    public priority: number = 420;
 
     public async execute(context: IBuildImageInAzureContext): Promise<void> {
         const id: number = Math.floor(Math.random() * Math.pow(10, idPrecision));

--- a/src/commands/deployImage/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/deployImage/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -12,7 +12,7 @@ import type { IBuildImageInAzureContext } from './IBuildImageInAzureContext';
 const vcsIgnoreList = ['.git', '.gitignore', '.bzr', 'bzrignore', '.hg', '.hgignore', '.svn'];
 
 export class UploadSourceCodeStep extends AzureWizardExecuteStep<IBuildImageInAzureContext> {
-    public priority: number = 175;
+    public priority: number = 430;
 
     public async execute(context: IBuildImageInAzureContext): Promise<void> {
         context.registryName = nonNullValue(context.registry?.name);

--- a/src/commands/deployImage/imageSource/containerRegistry/ContainerRegistryImageConfigureStep.ts
+++ b/src/commands/deployImage/imageSource/containerRegistry/ContainerRegistryImageConfigureStep.ts
@@ -12,7 +12,7 @@ import { getLoginServer } from "./getLoginServer";
 import { getAcrCredentialsAndSecrets, getThirdPartyCredentialsAndSecrets } from "./getRegistryCredentialsAndSecrets";
 
 export class ContainerRegistryImageConfigureStep extends AzureWizardExecuteStep<IContainerRegistryImageContext> {
-    public priority: number = 240;
+    public priority: number = 470;
 
     // Configures base image attributes
     public async execute(context: IContainerRegistryImageContext): Promise<void> {

--- a/src/commands/deployImage/imageSource/containerRegistry/acr/createAcr/RegistryCreateStep.ts
+++ b/src/commands/deployImage/imageSource/containerRegistry/acr/createAcr/RegistryCreateStep.ts
@@ -10,7 +10,7 @@ import { createContainerRegistryManagementClient } from "../../../../../../utils
 import { CreateAcrContext } from "./CreateAcrContext";
 
 export class RegistryCreateStep extends AzureWizardExecuteStep<CreateAcrContext> {
-    public priority: number = 150;
+    public priority: number = 350;
 
     public async execute(context: CreateAcrContext): Promise<void> {
         const client: ContainerRegistryManagementClient = await createContainerRegistryManagementClient(context);

--- a/src/commands/ingress/disableIngress/DisableIngressStep.ts
+++ b/src/commands/ingress/disableIngress/DisableIngressStep.ts
@@ -11,7 +11,7 @@ import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
 import { isIngressEnabled } from "../isIngressEnabled";
 
 export class DisableIngressStep extends IngressUpdateBaseStep<IngressContext> {
-    public priority: number = 270;
+    public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp = nonNullProp(context, 'containerApp');

--- a/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
+++ b/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
@@ -10,7 +10,7 @@ import type { IngressContext } from "../IngressContext";
 import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
 
 export class TargetPortUpdateStep extends IngressUpdateBaseStep<IngressContext> {
-    public priority: number = 280;
+    public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp = nonNullProp(context, 'containerApp');

--- a/src/commands/ingress/enableIngress/EnableIngressStep.ts
+++ b/src/commands/ingress/enableIngress/EnableIngressStep.ts
@@ -11,7 +11,7 @@ import type { IngressContext } from "../IngressContext";
 import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
 
 export class EnableIngressStep extends IngressUpdateBaseStep<IngressContext> {
-    public priority: number = 290;
+    public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp = nonNullProp(context, 'containerApp');

--- a/src/commands/ingress/toggleIngressVisibility/ToggleIngressVisibilityStep.ts
+++ b/src/commands/ingress/toggleIngressVisibility/ToggleIngressVisibilityStep.ts
@@ -11,7 +11,7 @@ import type { IngressContext } from "../IngressContext";
 import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
 
 export class ToggleIngressVisibilityStep extends IngressUpdateBaseStep<IngressContext> {
-    public priority: number = 300;
+    public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp = nonNullProp(context, 'containerApp');

--- a/src/commands/revisionDraft/deployRevisionDraft/DeployRevisionDraftStep.ts
+++ b/src/commands/revisionDraft/deployRevisionDraft/DeployRevisionDraftStep.ts
@@ -14,7 +14,7 @@ import { updateContainerApp } from "../../../utils/updateContainerApp";
 import type { IDeployRevisionDraftContext } from "./IDeployRevisionDraftContext";
 
 export class DeployRevisionDraftStep extends AzureWizardExecuteStep<IDeployRevisionDraftContext> {
-    public priority: number = 260;
+    public priority: number = 1450;
 
     public async execute(context: IDeployRevisionDraftContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');

--- a/src/commands/scaling/addScaleRule/AddScaleRuleStep.ts
+++ b/src/commands/scaling/addScaleRule/AddScaleRuleStep.ts
@@ -14,7 +14,7 @@ import { RevisionDraftUpdateBaseStep } from "../../revisionDraft/RevisionDraftUp
 import type { IAddScaleRuleContext } from "./IAddScaleRuleContext";
 
 export class AddScaleRuleStep<T extends IAddScaleRuleContext> extends RevisionDraftUpdateBaseStep<T> {
-    public priority: number = 200;
+    public priority: number = 1120;
 
     constructor(baseItem: RevisionsItemModel) {
         super(baseItem);

--- a/src/commands/secret/addSecret/SecretCreateStep.ts
+++ b/src/commands/secret/addSecret/SecretCreateStep.ts
@@ -12,7 +12,7 @@ import { updateContainerApp } from "../../../utils/updateContainerApp";
 import type { ISecretContext } from "../ISecretContext";
 
 export class SecretCreateStep extends AzureWizardExecuteStep<ISecretContext> {
-    public priority: number = 200;
+    public priority: number = 820;
 
     public async execute(context: ISecretContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');

--- a/src/commands/secret/deleteSecret/SecretDeleteStep.ts
+++ b/src/commands/secret/deleteSecret/SecretDeleteStep.ts
@@ -12,7 +12,7 @@ import { updateContainerApp } from "../../../utils/updateContainerApp";
 import type { ISecretContext } from "../ISecretContext";
 
 export class SecretDeleteStep extends AzureWizardExecuteStep<ISecretContext> {
-    public priority: number = 850;
+    public priority: number = 200;
 
     public async execute(context: ISecretContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');

--- a/src/commands/secret/deleteSecret/SecretDeleteStep.ts
+++ b/src/commands/secret/deleteSecret/SecretDeleteStep.ts
@@ -12,7 +12,7 @@ import { updateContainerApp } from "../../../utils/updateContainerApp";
 import type { ISecretContext } from "../ISecretContext";
 
 export class SecretDeleteStep extends AzureWizardExecuteStep<ISecretContext> {
-    public priority: number = 200;
+    public priority: number = 850;
 
     public async execute(context: ISecretContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');

--- a/src/commands/secret/editSecret/SecretUpdateStep.ts
+++ b/src/commands/secret/editSecret/SecretUpdateStep.ts
@@ -12,7 +12,7 @@ import { updateContainerApp } from "../../../utils/updateContainerApp";
 import type { ISecretContext } from "../ISecretContext";
 
 export class SecretUpdateStep extends AzureWizardExecuteStep<ISecretContext> {
-    public priority: number = 200;
+    public priority: number = 850;
 
     public async execute(context: ISecretContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const containerApp: ContainerAppModel = nonNullProp(context, 'containerApp');


### PR DESCRIPTION
As part of the express deploy command work, I'm revisiting all the execute step priorities to ensure creations are completed in the correct order (a lot of these commands were being called programmatically by the user before, and so the execute step priority values hadn't been especially important).  

Let me know if you think a general priority markdown file like this would be useful for tracking.