### PR TITLE
Add `canSymbolsRepeat` option to `validateUtils` and improve invalid input messages

### DIFF
--- a/src/commands/secret/addSecret/SecretNameStep.ts
+++ b/src/commands/secret/addSecret/SecretNameStep.ts
@@ -29,9 +29,8 @@ export class SecretNameStep extends AzureWizardPromptStep<ISecretContext> {
             return validateUtils.getInvalidLengthMessage();
         }
 
-        const symbols: string = '-';
-        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols, true /** canSymbolsRepeat */)) {
-            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols, true /** canSymbolsRepeat */);
+        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value)) {
+            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage();
         }
 
         const secrets: Secret[] = context.containerApp?.configuration?.secrets ?? [];

--- a/src/commands/secret/addSecret/SecretNameStep.ts
+++ b/src/commands/secret/addSecret/SecretNameStep.ts
@@ -29,8 +29,9 @@ export class SecretNameStep extends AzureWizardPromptStep<ISecretContext> {
             return validateUtils.getInvalidLengthMessage();
         }
 
-        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value, '-' /** symbols */, true /** canSymbolsRepeat */)) {
-            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage();
+        const symbols: string = '-';
+        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols, true /** canSymbolsRepeat */)) {
+            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols, true /** canSymbolsRepeat */);
         }
 
         const secrets: Secret[] = context.containerApp?.configuration?.secrets ?? [];

--- a/src/commands/secret/addSecret/SecretNameStep.ts
+++ b/src/commands/secret/addSecret/SecretNameStep.ts
@@ -29,7 +29,7 @@ export class SecretNameStep extends AzureWizardPromptStep<ISecretContext> {
             return validateUtils.getInvalidLengthMessage();
         }
 
-        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value)) {
+        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(value, '-' /** symbols */, true /** canSymbolsRepeat */)) {
             return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage();
         }
 

--- a/src/utils/validateUtils.ts
+++ b/src/utils/validateUtils.ts
@@ -48,6 +48,7 @@ export namespace validateUtils {
      *
      * @param value The original input string to validate
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
+     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed
      *
      * @example
      * "abcd-1234" // returns true
@@ -64,6 +65,7 @@ export namespace validateUtils {
 
     /**
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
+     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed
      */
     export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-', canSymbolsRepeat?: boolean): string {
         const nonConsecutive: string = canSymbolsRepeat ? '' : localize('nonConsecutive', 'non-consecutive ');

--- a/src/utils/validateUtils.ts
+++ b/src/utils/validateUtils.ts
@@ -65,7 +65,8 @@ export namespace validateUtils {
     /**
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
      */
-    export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-'): string {
-        return localize('invalidLowerAlphanumericWithSymbols', `A name must consist of lower case alphanumeric characters or one of the following symbols: "{0}", and must start and end with a lower case alphanumeric character.`, symbols);
+    export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-', canSymbolsRepeat?: boolean): string {
+        const nonConsecutive: string = canSymbolsRepeat ? localize('nonConsecutive', 'non-consecutive ') : '';
+        return localize('invalidLowerAlphanumericWithSymbols', `A name must consist of lower-case alphanumeric characters or the following {0}symbols: "{1}", and must start and end with a lower case alphanumeric character.`, nonConsecutive, symbols);
     }
 }

--- a/src/utils/validateUtils.ts
+++ b/src/utils/validateUtils.ts
@@ -53,12 +53,13 @@ export namespace validateUtils {
      * "abcd-1234" // returns true
      * "-abcd-1234" // returns false
      */
-    export function isLowerCaseAlphanumericWithSymbols(value: string, symbols: string = '-'): boolean {
+    export function isLowerCaseAlphanumericWithSymbols(value: string, symbols: string = '-', canSymbolsRepeat?: boolean): boolean {
         // Search through the passed symbols and match any allowed symbols
         // If we find a match, escape the symbol using '\\$&'
         const symbolPattern: string = symbols.replace(new RegExp(allowedSymbols, 'g'), '\\$&');
         const pattern: RegExp = new RegExp(`^[a-z0-9](?:[a-z0-9${symbolPattern}]*[a-z0-9])?$`);
-        return pattern.test(value);
+        const symbolsRepeatPattern: RegExp = new RegExp('[^a-z0-9]{2}', 'g');
+        return pattern.test(value) && (!!canSymbolsRepeat || !symbolsRepeatPattern.test(value));
     }
 
     /**

--- a/src/utils/validateUtils.ts
+++ b/src/utils/validateUtils.ts
@@ -66,7 +66,7 @@ export namespace validateUtils {
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
      */
     export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-', canSymbolsRepeat?: boolean): string {
-        const nonConsecutive: string = canSymbolsRepeat ? localize('nonConsecutive', 'non-consecutive ') : '';
+        const nonConsecutive: string = canSymbolsRepeat ? '' : localize('nonConsecutive', 'non-consecutive ');
         return localize('invalidLowerAlphanumericWithSymbols', `A name must consist of lower-case alphanumeric characters or the following {0}symbols: "{1}", and must start and end with a lower case alphanumeric character.`, nonConsecutive, symbols);
     }
 }

--- a/src/utils/validateUtils.ts
+++ b/src/utils/validateUtils.ts
@@ -48,13 +48,13 @@ export namespace validateUtils {
      *
      * @param value The original input string to validate
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
-     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed
+     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed. Defaults to true.
      *
      * @example
      * "abcd-1234" // returns true
      * "-abcd-1234" // returns false
      */
-    export function isLowerCaseAlphanumericWithSymbols(value: string, symbols: string = '-', canSymbolsRepeat?: boolean): boolean {
+    export function isLowerCaseAlphanumericWithSymbols(value: string, symbols: string = '-', canSymbolsRepeat: boolean = true): boolean {
         // Search through the passed symbols and match any allowed symbols
         // If we find a match, escape the symbol using '\\$&'
         const symbolPattern: string = symbols.replace(new RegExp(allowedSymbols, 'g'), '\\$&');
@@ -65,9 +65,9 @@ export namespace validateUtils {
 
     /**
      * @param symbols Any custom symbols that are also allowed in the input string. Defaults to '-'.
-     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed
+     * @param canSymbolsRepeat A boolean specifying whether or not repeating or consecutive symbols are allowed. Defaults to true.
      */
-    export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-', canSymbolsRepeat?: boolean): string {
+    export function getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols: string = '-', canSymbolsRepeat: boolean = true): string {
         const nonConsecutive: string = canSymbolsRepeat ? '' : localize('nonConsecutive', 'non-consecutive ');
         return localize('invalidLowerAlphanumericWithSymbols', `A name must consist of lower-case alphanumeric characters or the following {0}symbols: "{1}", and must start and end with a lower case alphanumeric character.`, nonConsecutive, symbols);
     }

--- a/test/validateUtils.test.ts
+++ b/test/validateUtils.test.ts
@@ -15,7 +15,8 @@ suite('validateUtils', () => {
             { value: 'hello-world', symbols: '-' },
             { value: 'hello@world', symbols: '@%' },
             { value: 'he!l@l#o', symbols: '!@#' },
-            { value: 'hello--world', symbols: '-', canSymbolsRepeat: true },
+            { value: 'hello--world', symbols: '-' },
+            { value: 'hello---world', symbols: '-', canSymbolsRepeat: true },
             { value: 'a' },
             { value: '123' },
             { value: '12-3' },
@@ -33,11 +34,11 @@ suite('validateUtils', () => {
             { value: 'A' },
             { value: 'hello123-' },
             { value: '-hello123' },
-            { value: 'hello--world' },
+            { value: 'hello--world', symbols: '-', canSymbolsRepeat: false },
             { value: '12.3' },
             { value: '123-8.@9', symbols: '-.' },
             { value: 'he!l@l#o$', symbols: '!@#$' },
-            { value: 'he!l@l#$o', symbols: '!@#$' }
+            { value: 'he!l@l#$o', symbols: '!@#$', canSymbolsRepeat: false }
         ];
 
         for (const { value, symbols, canSymbolsRepeat } of falseValues) {

--- a/test/validateUtils.test.ts
+++ b/test/validateUtils.test.ts
@@ -4,6 +4,7 @@ import { validateUtils } from '../extension.bundle';
 type LowerCaseAlphanumericWithSymbolsParams = {
     value: string;
     symbols?: string;
+    canSymbolsRepeat?: boolean;
 };
 
 suite('validateUtils', () => {
@@ -13,16 +14,16 @@ suite('validateUtils', () => {
             { value: 'hello-world' },
             { value: 'hello-world', symbols: '-' },
             { value: 'hello@world', symbols: '@%' },
+            { value: 'he!l@l#o', symbols: '!@#' },
+            { value: 'hello--world', symbols: '-', canSymbolsRepeat: true },
             { value: 'a' },
             { value: '123' },
             { value: '12-3' },
             { value: 'he-ll-o' },
-            { value: '123-8.@9', symbols: '-.@' },
-            { value: 'he!l@l#$o', symbols: '!@#$' }
         ];
 
-        for (const { value, symbols } of trueValues) {
-            assert.equal(validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols), true);
+        for (const { value, symbols, canSymbolsRepeat } of trueValues) {
+            assert.equal(validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols, canSymbolsRepeat), true);
         }
 
         const falseValues: LowerCaseAlphanumericWithSymbolsParams[] = [
@@ -32,13 +33,15 @@ suite('validateUtils', () => {
             { value: 'A' },
             { value: 'hello123-' },
             { value: '-hello123' },
+            { value: 'hello--world' },
             { value: '12.3' },
             { value: '123-8.@9', symbols: '-.' },
-            { value: 'he!l@l#o$', symbols: '!@#$' }
+            { value: 'he!l@l#o$', symbols: '!@#$' },
+            { value: 'he!l@l#$o', symbols: '!@#$' }
         ];
 
-        for (const { value, symbols } of falseValues) {
-            assert.equal(validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols), false);
+        for (const { value, symbols, canSymbolsRepeat } of falseValues) {
+            assert.equal(validateUtils.isLowerCaseAlphanumericWithSymbols(value, symbols, canSymbolsRepeat), false);
         }
     });
 });


### PR DESCRIPTION
Closes #437 

Added the non-repeat option because a lot of Azure resources have this naming restriction and I'd like to be able to leverage this option for upcoming work.