### PR TITLE
Add `settingsUtil.getSetting`

### DIFF
--- a/src/utils/activityUtils.ts
+++ b/src/utils/activityUtils.ts
@@ -11,6 +11,6 @@ import { settingUtils } from "../utils/settingUtils";
 export async function createActivityContext(): Promise<ExecuteActivityContext> {
     return {
         registerActivity: async (activity) => (ext.rgApiV2 as AzureResourcesExtensionApiWithActivity).activity.registerActivity(activity),
-        suppressNotification: await settingUtils.getWorkspaceSetting('suppressActivityNotifications', undefined, undefined, 'azureResourceGroups'),
+        suppressNotification: await settingUtils.getSetting('suppressActivityNotifications', undefined, 'azureResourceGroups'),
     };
 }

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -74,6 +74,17 @@ export namespace settingUtils {
     }
 
     /**
+     * Iteratively retrieves one of the user's settings - sequentially checking for a defined value starting from the `WorkspaceFolder` up to the `Global` configuration target.
+     * @param key The key of the setting to retrieve
+     * @param fsPath The optional path of the workspace configuration settings
+     * @param prefix The optional extension prefix. Uses ext.prefix `containerApps` unless otherwise specified
+     */
+    export function getSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
+        const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
+        return projectConfiguration.get<T>(key);
+    }
+
+    /**
      * Searches through all open folders and gets the current workspace setting (as long as there are no conflicts)
      * Uses ext.prefix 'containerApps' unless otherwise specified
      */


### PR DESCRIPTION
So I forgot that the old `getWorkspaceSetting` also would check up to the user's global setting due to it being tied to `projectConfiguration.get`.  I originally thought the name was kind of misleading since it didn't always grab a workspace setting, but I forgot to mirror that hidden behavior for `createActivityContext` after I refactored.  

With this more generic `getSetting` implementation addition, we can carry over the same behavior while keeping the function names more in line with their intended behavior.