### PR TITLE
Clean up `Ingress` tree refreshing and activity title behaviors

### DIFF
--- a/src/commands/ingress/IngressUpdateBaseStep.ts
+++ b/src/commands/ingress/IngressUpdateBaseStep.ts
@@ -25,6 +25,5 @@ export abstract class IngressUpdateBaseStep<T extends IContainerAppContext> exte
         await updateContainerApp(context, context.subscription, containerApp, { configuration: { ingress: ingress as Ingress | undefined } });
 
         ext.outputChannel.appendLog(workCompleted);
-        ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
     }
 }

--- a/src/commands/ingress/IngressUpdateStepBase.ts
+++ b/src/commands/ingress/IngressUpdateStepBase.ts
@@ -16,7 +16,7 @@ type IngressOptions = {
     workCompleted: string
 }
 
-export abstract class IngressUpdateBaseStep<T extends IContainerAppContext> extends AzureWizardExecuteStep<T> {
+export abstract class IngressUpdateStepBase<T extends IContainerAppContext> extends AzureWizardExecuteStep<T> {
     protected async updateIngressSettings(context: T, progress: Progress<{ message?: string | undefined }>, options: IngressOptions): Promise<void> {
         const containerApp = nonNullProp(context, 'containerApp');
         const { ingress, working, workCompleted } = options;

--- a/src/commands/ingress/disableIngress/DisableIngressStep.ts
+++ b/src/commands/ingress/disableIngress/DisableIngressStep.ts
@@ -7,10 +7,10 @@ import { nonNullProp } from "@microsoft/vscode-azext-utils";
 import type { Progress } from "vscode";
 import { localize } from "../../../utils/localize";
 import type { IngressContext } from "../IngressContext";
-import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
+import { IngressUpdateStepBase } from "../IngressUpdateStepBase";
 import { isIngressEnabled } from "../isIngressEnabled";
 
-export class DisableIngressStep extends IngressUpdateBaseStep<IngressContext> {
+export class DisableIngressStep extends IngressUpdateStepBase<IngressContext> {
     public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {

--- a/src/commands/ingress/disableIngress/disableIngress.ts
+++ b/src/commands/ingress/disableIngress/disableIngress.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, AzureWizardPromptStep, IActionContext, createSubscriptionContext } from '@microsoft/vscode-azext-utils';
+import { ext } from '../../../extensionVariables';
 import type { ContainerAppsItem } from "../../../tree/ContainerAppsBranchDataProvider";
 import { createActivityContext } from '../../../utils/activityUtils';
 import { localize } from '../../../utils/localize';
@@ -42,4 +43,6 @@ export async function disableIngress(context: IActionContext, node?: ContainerAp
 
     await wizard.prompt();
     await wizard.execute();
+
+    ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
 }

--- a/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
+++ b/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
@@ -7,9 +7,9 @@ import { nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils"
 import type { Progress } from "vscode";
 import { localize } from "../../../utils/localize";
 import type { IngressContext } from "../IngressContext";
-import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
+import { IngressUpdateStepBase } from "../IngressUpdateStepBase";
 
-export class TargetPortUpdateStep extends IngressUpdateBaseStep<IngressContext> {
+export class TargetPortUpdateStep extends IngressUpdateStepBase<IngressContext> {
     public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {

--- a/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
+++ b/src/commands/ingress/editTargetPort/TargetPortUpdateStep.ts
@@ -20,7 +20,6 @@ export class TargetPortUpdateStep extends IngressUpdateBaseStep<IngressContext> 
         const working: string = localize('updatingTargetPort', 'Updating target port...');
         const workCompleted: string = localize('updatedTargetPort', 'Updated target port to {0} for container app "{1}"', context.targetPort, containerApp.name);
 
-        context.activityTitle = localize('updateTargetPort', 'Update target port to {0} for container app "{1}"', context.targetPort, containerApp.name);
         await this.updateIngressSettings(context, progress, { ingress, working, workCompleted });
     }
 

--- a/src/commands/ingress/editTargetPort/editTargetPort.ts
+++ b/src/commands/ingress/editTargetPort/editTargetPort.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createSubscriptionContext, IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../../extensionVariables";
 import { IngressEnabledItem } from "../../../tree/configurations/IngressItem";
 import type { ContainerAppItem } from "../../../tree/ContainerAppItem";
 import { createActivityContext } from "../../../utils/activityUtils";
@@ -42,5 +43,8 @@ export async function editTargetPort(context: IActionContext, node?: IngressEnab
     });
 
     await wizard.prompt();
+    wizardContext.activityTitle = localize('updateTargetPort', 'Update target port to {0} for container app "{1}"', wizardContext.targetPort, containerApp.name);
     await wizard.execute();
+
+    ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
 }

--- a/src/commands/ingress/enableIngress/EnableIngressStep.ts
+++ b/src/commands/ingress/enableIngress/EnableIngressStep.ts
@@ -31,7 +31,6 @@ export class EnableIngressStep extends IngressUpdateBaseStep<IngressContext> {
         const working: string = localize('enablingIngress', 'Enabling ingress...');
         const workCompleted: string = localize('enableCompleted', 'Enabled ingress on port {0} for container app "{1}"', context.targetPort, containerApp.name)
 
-        context.activityTitle = localize('enableIngress', 'Enable ingress on port {0} for container app "{1}"', context.targetPort, containerApp.name);
         await this.updateIngressSettings(context, progress, { ingress, working, workCompleted });
     }
 

--- a/src/commands/ingress/enableIngress/EnableIngressStep.ts
+++ b/src/commands/ingress/enableIngress/EnableIngressStep.ts
@@ -8,9 +8,9 @@ import { nonNullProp } from "@microsoft/vscode-azext-utils";
 import type { Progress } from "vscode";
 import { localize } from "../../../utils/localize";
 import type { IngressContext } from "../IngressContext";
-import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
+import { IngressUpdateStepBase } from "../IngressUpdateStepBase";
 
-export class EnableIngressStep extends IngressUpdateBaseStep<IngressContext> {
+export class EnableIngressStep extends IngressUpdateStepBase<IngressContext> {
     public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {

--- a/src/commands/ingress/enableIngress/enableIngress.ts
+++ b/src/commands/ingress/enableIngress/enableIngress.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, AzureWizardPromptStep, createSubscriptionContext, IActionContext } from '@microsoft/vscode-azext-utils';
+import { ext } from '../../../extensionVariables';
 import type { ContainerAppsItem } from "../../../tree/ContainerAppsBranchDataProvider";
 import { createActivityContext } from '../../../utils/activityUtils';
 import { localize } from '../../../utils/localize';
@@ -36,5 +37,8 @@ export async function enableIngress(context: IActionContext, node?: ContainerApp
     });
 
     await wizard.prompt();
+    wizardContext.activityTitle = localize('enableIngress', 'Enable ingress on port {0} for container app "{1}"', wizardContext.targetPort, containerApp.name);
     await wizard.execute();
+
+    ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
 }

--- a/src/commands/ingress/toggleIngressVisibility/ToggleIngressVisibilityStep.ts
+++ b/src/commands/ingress/toggleIngressVisibility/ToggleIngressVisibilityStep.ts
@@ -8,9 +8,9 @@ import type { Progress } from "vscode";
 import { IngressConstants } from "../../../constants";
 import { localize } from "../../../utils/localize";
 import type { IngressContext } from "../IngressContext";
-import { IngressUpdateBaseStep } from "../IngressUpdateBaseStep";
+import { IngressUpdateStepBase } from "../IngressUpdateStepBase";
 
-export class ToggleIngressVisibilityStep extends IngressUpdateBaseStep<IngressContext> {
+export class ToggleIngressVisibilityStep extends IngressUpdateStepBase<IngressContext> {
     public priority: number = 650;
 
     public async execute(context: IngressContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {

--- a/src/commands/ingress/toggleIngressVisibility/toggleIngressVisibility.ts
+++ b/src/commands/ingress/toggleIngressVisibility/toggleIngressVisibility.ts
@@ -1,6 +1,7 @@
 import type { Ingress } from "@azure/arm-appcontainers";
 import { AzureWizard, AzureWizardExecuteStep, IActionContext, createSubscriptionContext, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { IngressConstants } from "../../../constants";
+import { ext } from "../../../extensionVariables";
 import type { ContainerAppItem } from "../../../tree/ContainerAppItem";
 import type { IngressEnabledItem } from "../../../tree/configurations/IngressItem";
 import { createActivityContext } from "../../../utils/activityUtils";
@@ -36,4 +37,6 @@ export async function toggleIngressVisibility(context: IActionContext, node?: In
     // Title normally gets set during prompt phase... since no prompt steps are provided we must set the 'activityTitle' manually
     wizardContext.activityTitle = title;
     await wizard.execute();
+
+    ext.state.notifyChildrenChanged(containerApp.managedEnvironmentId);
 }


### PR DESCRIPTION
Since some of these steps are re-usable, it doesn't make sense to make activity title and refresh changes in the execute steps themselves.  I wish I had realized this earlier, but I pulled these behaviors out and attached them to the commands instead and will implement this way going forward.