### PR TITLE
Add ability to choose an existing managed environment for `deployWorkspaceProject`

### DIFF
--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -88,14 +88,14 @@ export async function deployWorkspaceProject(context: IActionContext): Promise<v
         wizardContext.activityChildren?.push(
             new GenericTreeItem(undefined, {
                 contextValue: createActivityChildContext(['useExistingManagedEnvironment', activitySuccessContext]),
-                label: localize('useManagedEnvironment', 'Using container app environment "{0}"', managedEnvironmentName),
+                label: localize('useManagedEnvironment', 'Using container apps environment "{0}"', managedEnvironmentName),
                 iconPath: activityInfoIcon
             })
         );
 
         await LocationListStep.setLocation(wizardContext, wizardContext.managedEnvironment.location);
 
-        ext.outputChannel.appendLog(localize('usingManagedEnvironment', 'Using container app environment "{0}".', managedEnvironmentName));
+        ext.outputChannel.appendLog(localize('usingManagedEnvironment', 'Using container apps environment "{0}".', managedEnvironmentName));
         ext.outputChannel.appendLog(localize('useLocation', 'Using location "{0}".', wizardContext.managedEnvironment.location));
     } else {
         executeSteps.push(

--- a/src/commands/deployWorkspaceProject/getDefaultValues/getDefaultContainerAppsResources.ts
+++ b/src/commands/deployWorkspaceProject/getDefaultValues/getDefaultContainerAppsResources.ts
@@ -5,13 +5,13 @@
 
 import { ContainerApp, ContainerAppsAPIClient, ManagedEnvironment } from "@azure/arm-appcontainers";
 import type { ResourceGroup } from "@azure/arm-resources";
-import { ResourceGroupListStep, uiUtils } from "@microsoft/vscode-azext-azureutils";
-import type { ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
+import { ResourceGroupListStep, getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { nonNullProp, type IAzureQuickPickItem, type ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../../extensionVariables";
 import { ContainerAppItem, ContainerAppModel } from "../../../tree/ContainerAppItem";
 import { createContainerAppsAPIClient } from "../../../utils/azureClients";
 import { localize } from "../../../utils/localize";
-import { DeployWorkspaceProjectSettings } from "../deployWorkspaceProjectSettings";
+import type { DeployWorkspaceProjectSettings } from "../deployWorkspaceProjectSettings";
 
 interface DefaultContainerAppsResources {
     resourceGroup?: ResourceGroup;
@@ -19,13 +19,24 @@ interface DefaultContainerAppsResources {
     containerApp?: ContainerAppModel;
 }
 
-export async function getDefaultContainerAppsResources(context: ISubscriptionActionContext, settings: DeployWorkspaceProjectSettings | undefined): Promise<DefaultContainerAppsResources> {
-    const noMatchingResources = {
-        resourceGroup: undefined,
-        managedEnvironment: undefined,
-        containerApp: undefined
-    };
+const noMatchingResources = {
+    resourceGroup: undefined,
+    managedEnvironment: undefined,
+    containerApp: undefined
+};
 
+export async function getDefaultContainerAppsResources(context: ISubscriptionActionContext, settings: DeployWorkspaceProjectSettings | undefined): Promise<DefaultContainerAppsResources> {
+    // Try to obtain container app resources using any saved workspace settings
+    const { resourceGroup, managedEnvironment, containerApp } = await getContainerAppResourcesFromSettings(context, settings);
+    if (resourceGroup && managedEnvironment && containerApp) {
+        return { resourceGroup, managedEnvironment, containerApp };
+    }
+
+    // Otherwise see if the user has any managed environment resources to leverage
+    return await promptForContainerAppsEnvironmentResources(context);
+}
+
+async function getContainerAppResourcesFromSettings(context: ISubscriptionActionContext, settings: DeployWorkspaceProjectSettings | undefined): Promise<DefaultContainerAppsResources> {
     if (!settings || !settings.containerAppResourceGroupName || !settings.containerAppName) {
         return noMatchingResources;
     }
@@ -55,4 +66,39 @@ export async function getDefaultContainerAppsResources(context: ISubscriptionAct
         ext.outputChannel.appendLog(localize('noResourceMatch', 'Used saved workspace settings to search for container app "{0}" in resource group "{1}" but found no match.', settings.containerAppName, settings.containerAppResourceGroupName));
         return noMatchingResources;
     }
+}
+
+async function promptForContainerAppsEnvironmentResources(context: ISubscriptionActionContext): Promise<DefaultContainerAppsResources> {
+    const client: ContainerAppsAPIClient = await createContainerAppsAPIClient(context)
+    const managedEnvironments: ManagedEnvironment[] = await uiUtils.listAllIterator(client.managedEnvironments.listBySubscription());
+
+    if (!managedEnvironments.length) {
+        return noMatchingResources;
+    }
+
+    const picks: IAzureQuickPickItem<ManagedEnvironment | undefined>[] = [
+        {
+            label: localize('newManagedEnvironment', '$(plus) Create new container apps environment'),
+            description: '',
+            data: undefined
+        },
+        ...managedEnvironments.map(env => {
+            return {
+                label: nonNullProp(env, 'name'),
+                description: '',
+                data: env
+            };
+        })
+    ];
+
+    const placeHolder: string = localize('selectManagedEnvironment', 'Select a container apps environment');
+    const managedEnvironment: ManagedEnvironment | undefined = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+
+    if (!managedEnvironment) {
+        return noMatchingResources;
+    }
+
+    const resourceGroups: ResourceGroup[] = await ResourceGroupListStep.getResourceGroups(context);
+    const resourceGroup = resourceGroups.find(rg => rg.name === getResourceGroupFromId(nonNullProp(managedEnvironment, 'id')));
+    return { resourceGroup, managedEnvironment, containerApp: undefined };
 }


### PR DESCRIPTION
![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/0fed67e5-1063-4e09-b31d-092c9c450caf)

Some of this logic can probably be eventually re-purposed into a `ManagedEnvironmentListStep`