### PR TITLE
Increase draft creation visibility in the tree view

### DIFF
--- a/src/commands/revisionDraft/RevisionDraftFileSystem.ts
+++ b/src/commands/revisionDraft/RevisionDraftFileSystem.ts
@@ -6,7 +6,7 @@
 import { KnownActiveRevisionsMode, type Template } from "@azure/arm-appcontainers";
 import { ParsedAzureResourceId, parseAzureResourceId } from "@microsoft/vscode-azext-azureutils";
 import { nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
-import { Disposable, Event, EventEmitter, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, TextDocument, Uri, window, workspace } from "vscode";
+import { Disposable, Event, EventEmitter, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, TextDocument, Uri, commands, window, workspace } from "vscode";
 import { URI } from "vscode-uri";
 import { ext } from "../../extensionVariables";
 import { ContainerAppItem, ContainerAppModel } from "../../tree/ContainerAppItem";
@@ -132,6 +132,8 @@ export class RevisionDraftFileSystem implements FileSystemProvider {
         this.draftStore.set(uri.path, file);
         this.fireSoon({ type: FileChangeType.Changed, uri });
 
+        // Currently the container app id reveals only the hidden container app resources, so we'll have to make due with expanding the parent for now
+        void commands.executeCommand('azureResourceGroups.revealResource', file.containerApp.managedEnvironmentId, { select: false, expand: true });
         ext.state.notifyChildrenChanged(file.containerApp.managedEnvironmentId);
     }
 

--- a/src/commands/revisionDraft/RevisionDraftFileSystem.ts
+++ b/src/commands/revisionDraft/RevisionDraftFileSystem.ts
@@ -12,6 +12,7 @@ import { ext } from "../../extensionVariables";
 import { ContainerAppItem, ContainerAppModel } from "../../tree/ContainerAppItem";
 import type { ContainerAppsItem } from "../../tree/ContainerAppsBranchDataProvider";
 import type { RevisionsItemModel } from "../../tree/revisionManagement/RevisionItem";
+import { RevisionsItem } from "../../tree/revisionManagement/RevisionsItem";
 import { localize } from "../../utils/localize";
 
 const notSupported: string = localize('notSupported', 'This operation is not currently supported.');
@@ -62,6 +63,12 @@ export class RevisionDraftFileSystem implements FileSystemProvider {
             const revisionContent: Uint8Array = Buffer.from(JSON.stringify(nonNullValueAndProp(item.containerApp, 'template'), undefined, 4));
             file = new RevisionDraftFile(revisionContent, item.containerApp, nonNullValueAndProp(item.containerApp, 'latestRevisionName'));
         } else {
+            // A trick to help the draft item appear properly when the parent isn't already expanded (covers the command palette entrypoints)
+            void ext.state.showCreatingChild(
+                RevisionsItem.getRevisionsItemId(item.containerApp.id),
+                localize('creatingDraft', 'Creating draft...'),
+                () => Promise.resolve());
+
             const revisionContent: Uint8Array = Buffer.from(JSON.stringify(nonNullValueAndProp(item.revision, 'template'), undefined, 4));
             file = new RevisionDraftFile(revisionContent, item.containerApp, nonNullValueAndProp(item.revision, 'name'));
         }

--- a/src/commands/revisionDraft/createRevisionDraft.ts
+++ b/src/commands/revisionDraft/createRevisionDraft.ts
@@ -13,7 +13,6 @@ import { ext } from "../../extensionVariables";
 import type { RevisionItem } from "../../tree/revisionManagement/RevisionItem";
 import { RevisionsItem } from "../../tree/revisionManagement/RevisionsItem";
 import { createContainerAppsAPIClient } from "../../utils/azureClients";
-import { delay } from "../../utils/delay";
 import { localize } from "../../utils/localize";
 import { pickContainerApp } from "../../utils/pickItem/pickContainerApp";
 import { pickRevision } from "../../utils/pickItem/pickRevision";
@@ -47,15 +46,7 @@ export async function createRevisionDraft(context: IActionContext, node?: Revisi
         selectByRevisionName: revisionName
     });
 
-    await ext.state.showCreatingChild(
-        `${revisionItem.containerApp.id}/${RevisionsItem.idSuffix}`,
-        localize('creatingDraft', 'Creating draft...'),
-        async () => {
-            // Add a short delay to display the creating message
-            await delay(5);
-            ext.revisionDraftFileSystem.createRevisionDraft(revisionItem);
-        }
-    );
+    ext.revisionDraftFileSystem.createRevisionDraft(revisionItem);
 }
 
 async function promptForRevisionName(context: IContainerAppContext): Promise<string | undefined> {

--- a/src/commands/revisionDraft/deployRevisionDraft/DeployRevisionDraftStep.ts
+++ b/src/commands/revisionDraft/deployRevisionDraft/DeployRevisionDraftStep.ts
@@ -33,7 +33,7 @@ export class DeployRevisionDraftStep extends AzureWizardExecuteStep<IDeployRevis
 
         progress.report({ message: updating });
 
-        const id: string = containerApp.revisionsMode === KnownActiveRevisionsMode.Single ? containerApp.id : `${containerApp.id}/${RevisionDraftItem.idSuffix}`;
+        const id: string = containerApp.revisionsMode === KnownActiveRevisionsMode.Single ? containerApp.id : RevisionDraftItem.getRevisionDraftItemId(containerApp.id);
 
         await ext.state.runWithTemporaryDescription(id, description, async () => {
             await updateContainerApp(context, context.subscription, containerAppEnvelope);

--- a/src/commands/revisionDraft/deployRevisionDraft/deployRevisionDraft.ts
+++ b/src/commands/revisionDraft/deployRevisionDraft/deployRevisionDraft.ts
@@ -60,7 +60,7 @@ export async function deployRevisionDraft(context: IActionContext, node?: Contai
         ext.revisionDraftFileSystem.discardRevisionDraft(item);
     } else {
         await ext.state.showDeleting(
-            `${item.containerApp.id}/${RevisionDraftItem.idSuffix}`,
+            RevisionDraftItem.getRevisionDraftItemId(item.containerApp.id),
             async () => {
                 // Add a short delay to display the deleting message
                 await delay(5);

--- a/src/commands/revisionDraft/discardRevisionDraft.ts
+++ b/src/commands/revisionDraft/discardRevisionDraft.ts
@@ -22,7 +22,7 @@ export async function discardRevisionDraft(context: IActionContext, node?: Conta
         ext.revisionDraftFileSystem.discardRevisionDraft(containerAppsItem);
     } else {
         await ext.state.showDeleting(
-            `${containerAppsItem.containerApp.id}/${RevisionDraftItem.idSuffix}`,
+            RevisionDraftItem.getRevisionDraftItemId(containerAppsItem.containerApp.id),
             async () => {
                 // Add a short delay to display the deleting message
                 await delay(5);

--- a/src/tree/revisionManagement/RevisionDraftItem.ts
+++ b/src/tree/revisionManagement/RevisionDraftItem.ts
@@ -23,7 +23,7 @@ export interface RevisionsDraftModel {
 }
 
 export class RevisionDraftItem implements RevisionsItemModel, RevisionsDraftModel {
-    static readonly idSuffix: string = 'revisionDraft';
+    static readonly idSuffix: string = '/revisionDraft';
     static readonly contextValue: string = 'revisionDraftItem';
     static readonly contextValueRegExp: RegExp = new RegExp(RevisionDraftItem.contextValue);
 
@@ -31,7 +31,7 @@ export class RevisionDraftItem implements RevisionsItemModel, RevisionsDraftMode
     revisionsMode: KnownActiveRevisionsMode;
 
     constructor(readonly subscription: AzureSubscription, readonly containerApp: ContainerAppModel, readonly revision: Revision) {
-        this.id = `${this.containerApp.id}/${RevisionDraftItem.idSuffix}`;
+        this.id = RevisionDraftItem.getRevisionDraftItemId(containerApp.id);
         this.revisionsMode = containerApp.revisionsMode;
     }
 
@@ -50,6 +50,10 @@ export class RevisionDraftItem implements RevisionsItemModel, RevisionsDraftMode
         const values: string[] = [RevisionDraftItem.contextValue];
         values.push(await this.hasUnsavedChanges() ? unsavedChangesTrueContextValue : unsavedChangesFalseContextValue);
         return createContextValue(values);
+    }
+
+    static getRevisionDraftItemId(containerAppId: string): string {
+        return `${containerAppId}/${RevisionDraftItem.idSuffix}`;
     }
 
     static isRevisionDraftItem(item: unknown): item is RevisionDraftItem {

--- a/src/tree/revisionManagement/RevisionsItem.ts
+++ b/src/tree/revisionManagement/RevisionsItem.ts
@@ -19,20 +19,23 @@ import { RevisionDraftItem } from "./RevisionDraftItem";
 import { RevisionItem } from "./RevisionItem";
 
 export class RevisionsItem implements ContainerAppsItem {
-    static readonly idSuffix: string = 'revisions';
     static readonly contextValue: string = 'revisionsItem';
     static readonly contextValueRegExp: RegExp = new RegExp(RevisionsItem.contextValue);
 
     id: string;
 
     constructor(public readonly subscription: AzureSubscription, public readonly containerApp: ContainerAppModel) {
-        this.id = `${containerApp.id}/${RevisionsItem.idSuffix}`;
+        this.id = RevisionsItem.getRevisionsItemId(containerApp.id);
     }
 
     private get contextValue(): string {
         const values: string[] = [RevisionsItem.contextValue];
         values.push(ext.revisionDraftFileSystem.doesContainerAppsItemHaveRevisionDraft(this) ? revisionDraftTrueContextValue : revisionDraftFalseContextValue);
         return createContextValue(values);
+    }
+
+    static getRevisionsItemId(containerAppId: string): string {
+        return `${containerAppId}/revisions`;
     }
 
     async getChildren(): Promise<TreeElementBase[]> {


### PR DESCRIPTION
Anthony brought this scenario up a while back.  When running certain draft commands without the tree expanded, it may be difficult to locate changes.  I did my best to expand basically as high as we can currently go with reveal.  I can't reveal the actual container app because the id is currently tied to the hidden resource and not the container apps shown under the managed environment group.

I also moved the `showCreatingChild` into the `RevisionDraftFileSystem` create method so that the tree item shows up properly regardless of the command entry-point.