### PR TITLE
Shorten the container app creation description

### DIFF
--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -67,7 +67,7 @@ export async function createContainerApp(context: IActionContext, node?: Managed
 
     await ext.state.showCreatingChild(
         node.managedEnvironment.id,
-        localize('creatingContainerApp', 'Creating container app "{0}"...', newContainerAppName),
+        localize('creating', 'Creating "{0}"...', newContainerAppName),
         async () => {
             wizardContext.activityTitle = localize('createNamedContainerApp', 'Create container app "{0}"', newContainerAppName);
             await wizard.execute();


### PR DESCRIPTION
I think it looks better shorter, what do you think?

![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/60a638f2-9fe8-4593-810c-9ef4302c007d)

vs.

![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/33ab83ab-84f3-4446-9856-c05af4226710)
