### PR TITLE
Update location setting behavior for `deployWorkspaceProject`

### DIFF
--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -94,7 +94,10 @@ export async function deployWorkspaceProject(context: IActionContext, item?: Con
             })
         );
 
-        await LocationListStep.setLocation(wizardContext, wizardContext.managedEnvironment.location);
+        if (!LocationListStep.hasLocation(wizardContext)) {
+            await LocationListStep.setLocation(wizardContext, wizardContext.managedEnvironment.location);
+        }
+
         ext.outputChannel.appendLog(localize('usingManagedEnvironment', 'Using container apps environment "{0}".', managedEnvironmentName));
     } else {
         executeSteps.push(
@@ -142,7 +145,9 @@ export async function deployWorkspaceProject(context: IActionContext, item?: Con
 
         ext.outputChannel.appendLog(localize('usingContainerApp', 'Using container app "{0}".', containerAppName));
 
-        await LocationListStep.setLocation(wizardContext, wizardContext.containerApp.location);
+        if (!LocationListStep.hasLocation(wizardContext)) {
+            await LocationListStep.setLocation(wizardContext, wizardContext.containerApp.location);
+        }
     } else {
         executeSteps.push(new ContainerAppCreateStep());
     }


### PR DESCRIPTION
I was thinking it may make more sense to set the location to match the highest resource specificity.  

Previously I stopped at the managed environment level, but started thinking that maybe it makes more sense to override with the container app location if one is found.  Pretty much the only resource which would remain to be created in that scenario would be the container registry.. Thoughts?