### PR TITLE
Simplify deploy pop-up wording

### DIFF
--- a/src/commands/revisionDraft/RevisionDraftUpdateBaseStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftUpdateBaseStep.ts
@@ -61,7 +61,7 @@ export abstract class RevisionDraftUpdateBaseStep<T extends IContainerAppContext
         const no: string = localize('no', 'No');
         const dontShowAgain: string = localize('dontShowAgain', 'Don\'t show again');
 
-        const message: string = localize('message', 'Would you like to deploy these changes? Click "Yes" to proceed, or "No" to continue making changes.');
+        const message: string = localize('message', 'Deploy changes now?');
         const buttonMessages: string[] = [yes, no, dontShowAgain];
 
         void window.showInformationMessage(message, ...buttonMessages).then(async (result: string | undefined) => {


### PR DESCRIPTION
Based on feedback, changing from the top image to the bottom one:

![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/8d906ab1-d96f-4a89-8125-b6aa8f40df82)
