### PR TITLE
Change "Delete Secret..." command confirmation message

### DIFF
--- a/src/commands/secret/deleteSecret/SecretDeleteConfirmStep.ts
+++ b/src/commands/secret/deleteSecret/SecretDeleteConfirmStep.ts
@@ -10,7 +10,7 @@ import type { ISecretContext } from "../ISecretContext";
 export class SecretDeleteConfirmStep extends AzureWizardPromptStep<ISecretContext> {
     public async prompt(context: ISecretContext): Promise<void> {
         await context.ui.showWarningMessage(
-            localize('secretDeleteWarning', 'Are you sure you want to delete secret "{0}"?', nonNullProp(context, 'secretName')),
+            localize('secretDeleteWarning', 'Are you sure you want to delete secret "{0}"? By deleting this secret if you restart revisions that use it, new revisions will fail.', nonNullProp(context, 'secretName')),
             { modal: true },
             { title: localize('delete', 'Delete') }
         );

--- a/src/commands/secret/deleteSecret/SecretDeleteConfirmStep.ts
+++ b/src/commands/secret/deleteSecret/SecretDeleteConfirmStep.ts
@@ -10,7 +10,7 @@ import type { ISecretContext } from "../ISecretContext";
 export class SecretDeleteConfirmStep extends AzureWizardPromptStep<ISecretContext> {
     public async prompt(context: ISecretContext): Promise<void> {
         await context.ui.showWarningMessage(
-            localize('secretDeleteWarning', 'Are you sure you want to delete secret "{0}"? By deleting this secret if you restart revisions that use it, new revisions will fail.', nonNullProp(context, 'secretName')),
+            localize('secretDeleteWarning', 'Are you sure you want to delete secret "{0}"? Restarting revisions that use it will fail once the secret is deleted.', nonNullProp(context, 'secretName')),
             { modal: true },
             { title: localize('delete', 'Delete') }
         );


### PR DESCRIPTION
Adding more info to the delete confirmation message to more resemble this message in the portal. 
![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/59709511/adeba382-e324-41ce-a328-65c04cfc39ba)
