### PR TITLE
Don't flag empty arrays when checking for unsupported features

### DIFF
--- a/src/commands/ContainerAppOverwriteConfirmStep.ts
+++ b/src/commands/ContainerAppOverwriteConfirmStep.ts
@@ -39,8 +39,8 @@ export class ContainerAppOverwriteConfirmStep<T extends IContainerAppContext> ex
 
             for (const container of containerApp.template.containers) {
                 // NOTE: these are all arrays so if they are empty, this will still return true
-                // but these should be undefined if not being utilized
-                return !!container.probes || !!container.volumeMounts || !!container.args;
+                // but the length on these should be 0 or undefined if not being utilized
+                return !!container.probes?.length || !!container.volumeMounts?.length || !!container.args?.length;
             }
         }
 


### PR DESCRIPTION
I had a container app that was built through VS Code produce an empty array (not sure why because they're usually `undefined`), and it was prompting me that there were unsupported features that may be lost.  I started inspecting and the culprit was an empty array `[]`.  

I think in the case of an empty array, it's essentially equal to the `undefined` scenarios, so we probably can skip showing this if length is `0` or `undefined`.