### PR TITLE
Bump utils to `v2.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@azure/storage-blob": "^12.4.1",
                 "@microsoft/vscode-azext-azureutils": "^2.0.0",
                 "@microsoft/vscode-azext-github": "^1.0.0",
-                "@microsoft/vscode-azext-utils": "^2.1.2",
+                "@microsoft/vscode-azext-utils": "^2.1.3",
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "buffer": "^6.0.3",
                 "dayjs": "^1.11.3",
@@ -889,9 +889,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.2.tgz",
-            "integrity": "sha512-q7eL93zTS0q4bUVZQqzVCi557/vlE62JVj7/XLI8lgDC6ADjqnxudI83e+D3R0xj2OiWHwJF9pDQIGunc/XzUA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
+            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
                 "@vscode/extension-telemetry": "^0.6.2",
@@ -12537,9 +12537,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.2.tgz",
-            "integrity": "sha512-q7eL93zTS0q4bUVZQqzVCi557/vlE62JVj7/XLI8lgDC6ADjqnxudI83e+D3R0xj2OiWHwJF9pDQIGunc/XzUA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
+            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
                 "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -608,7 +608,7 @@
         "@azure/storage-blob": "^12.4.1",
         "@microsoft/vscode-azext-azureutils": "^2.0.0",
         "@microsoft/vscode-azext-github": "^1.0.0",
-        "@microsoft/vscode-azext-utils": "^2.1.2",
+        "@microsoft/vscode-azext-utils": "^2.1.3",
         "@microsoft/vscode-azureresources-api": "^2.0.2",
         "buffer": "^6.0.3",
         "dayjs": "^1.11.3",


### PR DESCRIPTION
Adds error tree items by default on fail to the activity children