### PR TITLE
Automatically generate a unique name for registries

### DIFF
--- a/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryNameStep.ts
+++ b/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryNameStep.ts
@@ -57,7 +57,7 @@ export class RegistryNameStep extends AzureWizardPromptStep<CreateAcrContext> {
         let registryAvailable: boolean = false;
         let generatedName: string = '';
 
-        const timeoutSeconds: number = 60;
+        const timeoutSeconds: number = 15;
         const timeoutMs: number = timeoutSeconds * 1000;
         const start: number = Date.now();
 

--- a/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryNameStep.ts
+++ b/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryNameStep.ts
@@ -67,7 +67,7 @@ export class RegistryNameStep extends AzureWizardPromptStep<CreateAcrContext> {
             }
 
             generatedName = generateRelatedName(name);
-            registryAvailable = !!context.registry || await RegistryNameStep.isNameAvailable(context, generatedName);
+            registryAvailable = !!context.registry || !!(await RegistryNameStep.isNameAvailable(context, generatedName)).nameAvailable;
         } while (!registryAvailable)
 
         return generatedName;

--- a/test/deployWorkspaceProject/DefaultResourcesNameStep/DefaultResourcesNameStep.test.ts
+++ b/test/deployWorkspaceProject/DefaultResourcesNameStep/DefaultResourcesNameStep.test.ts
@@ -63,7 +63,6 @@ suite('DefaultResourcesNameStep', async () => {
                         containerApp: undefined,
                         newResourceGroupName: 'workspace-name',
                         newManagedEnvironmentName: 'workspace-name',
-                        newRegistryName: 'workspacename',
                         newContainerAppName: 'workspace-name',
                         imageName: 'workspace-name:latest'
                     } as MockDefaultResourcesNameStepContext,
@@ -93,7 +92,6 @@ suite('DefaultResourcesNameStep', async () => {
                         containerApp: undefined,
                         newResourceGroupName: 'user-name',
                         newManagedEnvironmentName: 'user-name',
-                        newRegistryName: 'username',
                         newContainerAppName: 'user-name',
                         imageName: 'user-name:latest'
                     } as MockDefaultResourcesNameStepContext,
@@ -125,7 +123,6 @@ suite('DefaultResourcesNameStep', async () => {
                         containerApp: undefined,
                         newResourceGroupName: undefined,
                         newManagedEnvironmentName: undefined,
-                        newRegistryName: 'workspacename',
                         newContainerAppName: 'workspace-name',
                         imageName: 'workspace-name:latest'
                     } as MockDefaultResourcesNameStepContext,
@@ -157,7 +154,6 @@ suite('DefaultResourcesNameStep', async () => {
                         containerApp: undefined,
                         newResourceGroupName: undefined,
                         newManagedEnvironmentName: undefined,
-                        newRegistryName: 'username',
                         newContainerAppName: 'user-name',
                         imageName: 'user-name:latest'
                     } as MockDefaultResourcesNameStepContext,
@@ -191,7 +187,6 @@ suite('DefaultResourcesNameStep', async () => {
                         containerApp: { name: 'acr-build-1' },
                         newResourceGroupName: undefined,
                         newManagedEnvironmentName: undefined,
-                        newRegistryName: undefined,
                         newContainerAppName: undefined,
                         imageName: 'acr-build-1:latest'
                     } as MockDefaultResourcesNameStepContext,
@@ -220,7 +215,6 @@ function getMockResultContext(context: MockDefaultResourcesNameStepContext): Moc
         containerApp: context.containerApp,
         newResourceGroupName: context.newResourceGroupName,
         newManagedEnvironmentName: context.newManagedEnvironmentName,
-        newRegistryName: context.newRegistryName,
         newContainerAppName: context.newContainerAppName,
         imageName: context.imageName
     };

--- a/test/deployWorkspaceProject/DefaultResourcesNameStep/MockDefaultResourcesNameStep.ts
+++ b/test/deployWorkspaceProject/DefaultResourcesNameStep/MockDefaultResourcesNameStep.ts
@@ -15,7 +15,6 @@ export interface MockDefaultResourcesNameStepContext {
 
     newResourceGroupName?: string;
     newManagedEnvironmentName?: string;
-    newRegistryName?: string;
     newContainerAppName?: string;
 
     imageName?: string;


### PR DESCRIPTION
Because registry names have to be globally unique, it's almost guaranteed to have failed the workspace name check. This ensures that the registry name will almost always be unique. 