### PR TITLE
If an incompatible tree item is passed, treat it as if no tree item was passed

### DIFF
--- a/src/commands/createContainerApp/createContainerApp.ts
+++ b/src/commands/createContainerApp/createContainerApp.ts
@@ -9,7 +9,7 @@ import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionCont
 import { webProvider } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { ContainerAppItem } from "../../tree/ContainerAppItem";
-import type { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
+import { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
 import { createActivityContext } from "../../utils/activity/activityUtils";
 import { isAzdExtensionInstalled } from "../../utils/azdUtils";
 import { localize } from "../../utils/localize";
@@ -22,6 +22,11 @@ import type { CreateContainerAppContext } from "./CreateContainerAppContext";
 import { showContainerAppNotification } from "./showContainerAppNotification";
 
 export async function createContainerApp(context: IActionContext, node?: ManagedEnvironmentItem): Promise<ContainerAppItem> {
+    // If an incompatible tree item is passed, treat it as if no item was passed
+    if (node && !ManagedEnvironmentItem.isManagedEnvironmentItem(node)) {
+        node = undefined;
+    }
+
     node ??= await pickEnvironment(context);
 
     const wizardContext: CreateContainerAppContext = {

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -32,6 +32,10 @@ import { getDefaultContextValues } from "./getDefaultValues/getDefaultContextVal
 export async function deployWorkspaceProject(context: IActionContext, item?: ContainerAppItem | ManagedEnvironmentItem): Promise<void> {
     ext.outputChannel.appendLog(localize('beginCommandExecution', '--------Initializing deploy workspace project--------'));
 
+    if (item && !ContainerAppItem.isContainerAppItem(item) && !ManagedEnvironmentItem.isManagedEnvironmentItem(item)) {
+        item = undefined;
+    }
+
     const subscription: AzureSubscription = await subscriptionExperience(context, ext.rgApiV2.resources.azureResourceTreeDataProvider);
     const subscriptionContext: ISubscriptionContext = createSubscriptionContext(subscription);
 

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -32,6 +32,7 @@ import { getDefaultContextValues } from "./getDefaultValues/getDefaultContextVal
 export async function deployWorkspaceProject(context: IActionContext, item?: ContainerAppItem | ManagedEnvironmentItem): Promise<void> {
     ext.outputChannel.appendLog(localize('beginCommandExecution', '--------Initializing deploy workspace project--------'));
 
+    // If an incompatible tree item is passed, treat it as if no item as passed
     if (item && !ContainerAppItem.isContainerAppItem(item) && !ManagedEnvironmentItem.isManagedEnvironmentItem(item)) {
         item = undefined;
     }

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -32,7 +32,7 @@ import { getDefaultContextValues } from "./getDefaultValues/getDefaultContextVal
 export async function deployWorkspaceProject(context: IActionContext, item?: ContainerAppItem | ManagedEnvironmentItem): Promise<void> {
     ext.outputChannel.appendLog(localize('beginCommandExecution', '--------Initializing deploy workspace project--------'));
 
-    // If an incompatible tree item is passed, treat it as if no item as passed
+    // If an incompatible tree item is passed, treat it as if no item was passed
     if (item && !ContainerAppItem.isContainerAppItem(item) && !ManagedEnvironmentItem.isManagedEnvironmentItem(item)) {
         item = undefined;
     }


### PR DESCRIPTION
Fixes #556 

Currently known to affect ribbon commands.