### PR TITLE
Ensure file system paths use the `fsPath` property

### DIFF
--- a/src/commands/image/imageSource/buildImageInAzure/TarFileStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/TarFileStep.ts
@@ -16,7 +16,7 @@ export class TarFileStep extends AzureWizardExecuteStep<BuildImageInAzureImageSo
     public async execute(context: BuildImageInAzureImageSourceContext): Promise<void> {
         const id: number = Math.floor(Math.random() * Math.pow(10, idPrecision));
         const archive = `sourceArchive${id}.tar.gz`;
-        context.tarFilePath = Utils.joinPath(URI.parse(os.tmpdir()), archive).path;
+        context.tarFilePath = Utils.joinPath(URI.parse(os.tmpdir()), archive).fsPath;
     }
 
     public shouldExecute(context: BuildImageInAzureImageSourceContext): boolean {

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -107,7 +107,7 @@ export namespace settingUtils {
     }
 
     export function getDefaultRootWorkspaceSettingsPath(rootWorkspaceFolder: WorkspaceFolder): string {
-        return path.join(rootWorkspaceFolder.uri.path, vscodeFolder, settingsFile);
+        return path.join(rootWorkspaceFolder.uri.fsPath, vscodeFolder, settingsFile);
     }
 
     function getLowestConfigurationLevel(projectConfiguration: WorkspaceConfiguration, key: string): ConfigurationTarget | undefined {

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -55,14 +55,14 @@ export async function selectWorkspaceFile(
         }
 
         if (options.autoSelectIfOne && files.length === 1) {
-            return files[0].path;
+            return files[0].fsPath;
         }
 
         quickPicks.push(...files.map((uri: Uri) => {
             return {
                 label: basename(uri.path),
                 description: uri.path,
-                data: uri.path
+                data: uri.fsPath
             };
         }));
 
@@ -82,7 +82,7 @@ export async function selectWorkspaceFile(
     if (input?.data === skipForNow) {
         return undefined;
     } else {
-        return input?.data || (await context.ui.showOpenDialog(options))[0].path;
+        return input?.data || (await context.ui.showOpenDialog(options))[0].fsPath;
     }
 }
 


### PR DESCRIPTION
Although it ends up working either way due to URI path normalization in `AzExtFsExtra`, it's more correct and less ambiguous to refer to `fsPath` instead of `path`.