### PR TITLE
Add `deployWorkspaceProjectInternal`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true,
-        "source.organizeImports": true
+        "source.fixAll.eslint": "explicit",
+        "source.organizeImports": "explicit"
     },
     "editor.formatOnSave": true,
     "editor.insertSpaces": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit",
-        "source.organizeImports": "explicit"
+        "source.fixAll.eslint": true,
+        "source.organizeImports": true
     },
     "editor.formatOnSave": true,
     "editor.insertSpaces": true,

--- a/src/commands/deployWorkspaceProject/DeployWorkspaceProjectConfirmStep.ts
+++ b/src/commands/deployWorkspaceProject/DeployWorkspaceProjectConfirmStep.ts
@@ -7,9 +7,13 @@ import { nonNullValue } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { OverwriteConfirmStepBase } from "../OverwriteConfirmStepBase";
-import  { type DeployWorkspaceProjectContext } from "./DeployWorkspaceProjectContext";
+import { type DeployWorkspaceProjectContext } from "./DeployWorkspaceProjectContext";
 
 export class DeployWorkspaceProjectConfirmStep extends OverwriteConfirmStepBase<DeployWorkspaceProjectContext> {
+    constructor(private readonly suppressConfirmation: boolean) {
+        super();
+    }
+
     protected async promptCore(context: DeployWorkspaceProjectContext): Promise<void> {
         const resourcesToCreate: string[] = [];
         if (!context.resourceGroup) {
@@ -59,6 +63,6 @@ export class DeployWorkspaceProjectConfirmStep extends OverwriteConfirmStepBase<
     }
 
     public shouldPrompt(): boolean {
-        return true;
+        return !this.suppressConfirmation;
     }
 }

--- a/src/commands/deployWorkspaceProject/DeployWorkspaceProjectContext.ts
+++ b/src/commands/deployWorkspaceProject/DeployWorkspaceProjectContext.ts
@@ -3,17 +3,27 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import  { type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
-import  { type SetTelemetryProps } from "../../telemetry/SetTelemetryProps";
-import  { type DeployWorkspaceProjectTelemetryProps as TelemetryProps } from "../../telemetry/commandTelemetryProps";
-import  { type CreateContainerAppBaseContext } from "../createContainerApp/CreateContainerAppContext";
-import  { type IManagedEnvironmentContext } from "../createManagedEnvironment/IManagedEnvironmentContext";
-import  { type BuildImageInAzureImageSourceBaseContext } from "../image/imageSource/buildImageInAzure/BuildImageInAzureImageSourceContext";
-import  { type CreateAcrContext } from "../image/imageSource/containerRegistry/acr/createAcr/CreateAcrContext";
+import { type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
+import { type SetTelemetryProps } from "../../telemetry/SetTelemetryProps";
+import { type DeployWorkspaceProjectTelemetryProps as TelemetryProps } from "../../telemetry/commandTelemetryProps";
+import { type IContainerAppContext } from "../IContainerAppContext";
+import { type CreateContainerAppBaseContext } from "../createContainerApp/CreateContainerAppContext";
+import { type IManagedEnvironmentContext } from "../createManagedEnvironment/IManagedEnvironmentContext";
+import { type BuildImageInAzureImageSourceBaseContext } from "../image/imageSource/buildImageInAzure/BuildImageInAzureImageSourceContext";
+import { type CreateAcrContext } from "../image/imageSource/containerRegistry/acr/createAcr/CreateAcrContext";
 
 // Use intersection typing instead of an interface here to bypass some minor (relatively trivial) type mismatch issues introduced by having to use the 'Partial' utility
-export type DeployWorkspaceProjectContext = IManagedEnvironmentContext & CreateContainerAppBaseContext & CreateAcrContext & Partial<BuildImageInAzureImageSourceBaseContext> & ExecuteActivityContext & DeployWorkspaceProjectTelemetryProps & {
-    shouldSaveDeploySettings?: boolean;
-};
+export type DeployWorkspaceProjectContext =
+    IContainerAppContext &
+    Partial<IManagedEnvironmentContext> &
+    Partial<CreateContainerAppBaseContext> &
+    Partial<CreateAcrContext> &
+    Partial<BuildImageInAzureImageSourceBaseContext> &
+    Partial<ExecuteActivityContext> &
+    DeployWorkspaceProjectTelemetryProps &
+    {
+        ignoreExistingDeploySettings?: boolean;
+        shouldSaveDeploySettings?: boolean;
+    };
 
 type DeployWorkspaceProjectTelemetryProps = SetTelemetryProps<TelemetryProps>;

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -11,7 +11,6 @@ import { type SetTelemetryProps } from "../../telemetry/SetTelemetryProps";
 import { type DeployWorkspaceProjectNotificationTelemetryProps as NotificationTelemetryProps } from "../../telemetry/commandTelemetryProps";
 import { ContainerAppItem, isIngressEnabled, type ContainerAppModel } from "../../tree/ContainerAppItem";
 import { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
-import { createActivityContext } from "../../utils/activity/activityUtils";
 import { localize } from "../../utils/localize";
 import { browseContainerApp } from "../browseContainerApp";
 import { type DeployWorkspaceProjectContext } from "./DeployWorkspaceProjectContext";
@@ -25,9 +24,6 @@ export async function deployWorkspaceProject(context: IActionContext & Partial<D
 
     const subscription: AzureSubscription = await subscriptionExperience(context, ext.rgApiV2.resources.azureResourceTreeDataProvider);
     const subscriptionContext: ISubscriptionContext = createSubscriptionContext(subscription);
-
-    const activityContext = await createActivityContext();
-    activityContext.activityChildren = [];
 
     const deployWorkspaceProjectInternalContext: DeployWorkspaceProjectInternalContext = Object.assign(context, {
         ...subscriptionContext,

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProject.ts
@@ -3,36 +3,21 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { LocationListStep, ResourceGroupCreateStep } from "@microsoft/vscode-azext-azureutils";
-import { AzureWizard, GenericTreeItem, activityInfoIcon, activitySuccessContext, callWithTelemetryAndErrorHandling, createSubscriptionContext, nonNullProp, nonNullValueAndProp, subscriptionExperience, type AzureWizardExecuteStep, type AzureWizardPromptStep, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { callWithTelemetryAndErrorHandling, createSubscriptionContext, nonNullProp, subscriptionExperience, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { type AzureSubscription } from "@microsoft/vscode-azureresources-api";
-import { ProgressLocation, window } from "vscode";
-import { appProvider, managedEnvironmentsId } from "../../constants";
+import { window } from "vscode";
 import { ext } from "../../extensionVariables";
 import { type SetTelemetryProps } from "../../telemetry/SetTelemetryProps";
 import { type DeployWorkspaceProjectNotificationTelemetryProps as NotificationTelemetryProps } from "../../telemetry/commandTelemetryProps";
 import { ContainerAppItem, isIngressEnabled, type ContainerAppModel } from "../../tree/ContainerAppItem";
 import { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
-import { createActivityChildContext, createActivityContext } from "../../utils/activity/activityUtils";
-import { getVerifyProvidersStep } from "../../utils/getVerifyProvidersStep";
+import { createActivityContext } from "../../utils/activity/activityUtils";
 import { localize } from "../../utils/localize";
 import { browseContainerApp } from "../browseContainerApp";
-import { ContainerAppCreateStep } from "../createContainerApp/ContainerAppCreateStep";
-import { LogAnalyticsCreateStep } from "../createManagedEnvironment/LogAnalyticsCreateStep";
-import { ManagedEnvironmentCreateStep } from "../createManagedEnvironment/ManagedEnvironmentCreateStep";
-import { ContainerAppUpdateStep } from "../image/imageSource/ContainerAppUpdateStep";
-import { ImageSourceListStep } from "../image/imageSource/ImageSourceListStep";
-import { IngressPromptStep } from "../ingress/IngressPromptStep";
-import { DeployWorkspaceProjectConfirmStep } from "./DeployWorkspaceProjectConfirmStep";
 import { type DeployWorkspaceProjectContext } from "./DeployWorkspaceProjectContext";
-import { DeployWorkspaceProjectSaveSettingsStep } from "./DeployWorkspaceProjectSaveSettingsStep";
-import { ShouldSaveDeploySettingsPromptStep } from "./ShouldSaveDeploySettingsPromptStep";
-import { DefaultResourcesNameStep } from "./getDefaultValues/DefaultResourcesNameStep";
-import { getDefaultContextValues } from "./getDefaultValues/getDefaultContextValues";
+import { deployWorkspaceProjectInternal, type DeployWorkspaceProjectInternalContext } from "./deployWorkspaceProjectInternal";
 
-export async function deployWorkspaceProject(context: IActionContext, item?: ContainerAppItem | ManagedEnvironmentItem): Promise<void> {
-    ext.outputChannel.appendLog(localize('beginCommandExecution', '--------Initializing deploy workspace project--------'));
-
+export async function deployWorkspaceProject(context: IActionContext & Partial<DeployWorkspaceProjectContext>, item?: ContainerAppItem | ManagedEnvironmentItem): Promise<void> {
     // If an incompatible tree item is passed, treat it as if no item was passed
     if (item && !ContainerAppItem.isContainerAppItem(item) && !ManagedEnvironmentItem.isManagedEnvironmentItem(item)) {
         item = undefined;
@@ -41,169 +26,23 @@ export async function deployWorkspaceProject(context: IActionContext, item?: Con
     const subscription: AzureSubscription = await subscriptionExperience(context, ext.rgApiV2.resources.azureResourceTreeDataProvider);
     const subscriptionContext: ISubscriptionContext = createSubscriptionContext(subscription);
 
-    // Show loading indicator while we configure default values
-    let defaultContextValues: Partial<DeployWorkspaceProjectContext> | undefined;
-    await window.withProgress({
-        location: ProgressLocation.Notification,
-        cancellable: false,
-        title: localize('loadingWorkspaceTitle', 'Loading workspace project deployment configurations...')
-    }, async () => {
-        defaultContextValues = await getDefaultContextValues({ ...context, ...subscriptionContext }, item);
-    });
+    const activityContext = await createActivityContext();
+    activityContext.activityChildren = [];
 
-    const wizardContext: DeployWorkspaceProjectContext = {
-        ...context,
+    const deployWorkspaceProjectInternalContext: DeployWorkspaceProjectInternalContext = Object.assign(context, {
         ...subscriptionContext,
-        ...await createActivityContext(),
-        ...defaultContextValues,
-        activityChildren: [],
-        subscription,
-    };
-
-    const promptSteps: AzureWizardPromptStep<DeployWorkspaceProjectContext>[] = [
-        new DeployWorkspaceProjectConfirmStep(),
-        new DefaultResourcesNameStep()
-    ];
-
-    const executeSteps: AzureWizardExecuteStep<DeployWorkspaceProjectContext>[] = [
-        new DeployWorkspaceProjectSaveSettingsStep()
-    ];
-
-    // Resource group
-    if (wizardContext.resourceGroup) {
-        wizardContext.telemetry.properties.existingResourceGroup = 'true';
-
-        const resourceGroupName: string = nonNullValueAndProp(wizardContext.resourceGroup, 'name');
-
-        wizardContext.activityChildren?.push(
-            new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingResourceGroup', activitySuccessContext]),
-                label: localize('useResourceGroup', 'Using resource group "{0}"', resourceGroupName),
-                iconPath: activityInfoIcon
-            })
-        );
-
-        await LocationListStep.setLocation(wizardContext, wizardContext.resourceGroup.location);
-        ext.outputChannel.appendLog(localize('usingResourceGroup', 'Using resource group "{0}".', resourceGroupName));
-    } else {
-        wizardContext.telemetry.properties.existingResourceGroup = 'false';
-        executeSteps.push(new ResourceGroupCreateStep());
-    }
-
-    // Managed environment
-    if (wizardContext.managedEnvironment) {
-        wizardContext.telemetry.properties.existingEnvironment = 'true';
-
-        const managedEnvironmentName: string = nonNullValueAndProp(wizardContext.managedEnvironment, 'name');
-
-        wizardContext.activityChildren?.push(
-            new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingManagedEnvironment', activitySuccessContext]),
-                label: localize('useManagedEnvironment', 'Using container apps environment "{0}"', managedEnvironmentName),
-                iconPath: activityInfoIcon
-            })
-        );
-
-        if (!LocationListStep.hasLocation(wizardContext)) {
-            await LocationListStep.setLocation(wizardContext, wizardContext.managedEnvironment.location);
-        }
-
-        ext.outputChannel.appendLog(localize('usingManagedEnvironment', 'Using container apps environment "{0}".', managedEnvironmentName));
-    } else {
-        wizardContext.telemetry.properties.existingEnvironment = 'false';
-
-        executeSteps.push(
-            new LogAnalyticsCreateStep(),
-            new ManagedEnvironmentCreateStep()
-        );
-    }
-
-    // Azure Container Registry
-    if (wizardContext.registry) {
-        wizardContext.telemetry.properties.existingRegistry = 'true';
-
-        const registryName: string = nonNullValueAndProp(wizardContext.registry, 'name');
-
-        wizardContext.activityChildren?.push(
-            new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingAcr', activitySuccessContext]),
-                label: localize('useAcr', 'Using container registry "{0}"', registryName),
-                iconPath: activityInfoIcon
-            })
-        );
-
-        ext.outputChannel.appendLog(localize('usingAcr', 'Using Azure Container Registry "{0}".', registryName));
-    } else {
-        // ImageSourceListStep can already handle this creation logic
-        wizardContext.telemetry.properties.existingRegistry = 'false';
-    }
-
-    // Container app
-    if (wizardContext.containerApp) {
-        wizardContext.telemetry.properties.existingContainerApp = 'true';
-
-        const containerAppName: string = nonNullValueAndProp(wizardContext.containerApp, 'name');
-
-        executeSteps.push(new ContainerAppUpdateStep());
-
-        wizardContext.activityChildren?.push(
-            new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingContainerApp', activitySuccessContext]),
-                label: localize('useContainerApp', 'Using container app "{0}"', containerAppName),
-                iconPath: activityInfoIcon
-            })
-        );
-
-        ext.outputChannel.appendLog(localize('usingContainerApp', 'Using container app "{0}".', containerAppName));
-
-        if (!LocationListStep.hasLocation(wizardContext)) {
-            await LocationListStep.setLocation(wizardContext, wizardContext.containerApp.location);
-        }
-    } else {
-        wizardContext.telemetry.properties.existingContainerApp = 'false';
-        executeSteps.push(new ContainerAppCreateStep());
-    }
-
-    promptSteps.push(
-        new ImageSourceListStep(),
-        new IngressPromptStep(),
-    );
-
-    // Verify providers
-    executeSteps.push(getVerifyProvidersStep<DeployWorkspaceProjectContext>());
-
-    // Location
-    if (LocationListStep.hasLocation(wizardContext)) {
-        wizardContext.telemetry.properties.existingLocation = 'true';
-        ext.outputChannel.appendLog(localize('useLocation', 'Using location "{0}".', (await LocationListStep.getLocation(wizardContext)).name));
-    } else {
-        wizardContext.telemetry.properties.existingLocation = 'false';
-        LocationListStep.addProviderForFiltering(wizardContext, appProvider, managedEnvironmentsId);
-        LocationListStep.addStep(wizardContext, promptSteps);
-    }
-
-    // Save deploy settings
-    promptSteps.push(new ShouldSaveDeploySettingsPromptStep());
-
-    const wizard: AzureWizard<DeployWorkspaceProjectContext> = new AzureWizard(wizardContext, {
-        title: localize('deployWorkspaceProjectTitle', 'Deploy workspace project to a container app'),
-        promptSteps,
-        executeSteps,
-        showLoadingPrompt: true
+        subscription
     });
 
-    await wizard.prompt();
+    const deployWorkspaceProjectResultContext: DeployWorkspaceProjectContext = await deployWorkspaceProjectInternal(deployWorkspaceProjectInternalContext, item, {
+        suppressActivity: false,
+        suppressConfirmation: false,
+        suppressContainerAppCreation: false,
+        suppressProgress: false,
+        suppressWizardTitle: false
+    });
 
-    wizardContext.activityTitle = localize('deployWorkspaceProjectActivityTitle', 'Deploy workspace project to container app "{0}"', wizardContext.containerApp?.name || nonNullProp(wizardContext, 'newContainerAppName'));
-
-    ext.outputChannel.appendLog(localize('beginCommandExecution', '--------Deploying workspace project to container app--------', wizardContext.containerApp?.name || nonNullProp(wizardContext, 'newContainerAppName')));
-    await wizard.execute();
-
-    displayNotification(wizardContext);
-    wizardContext.telemetry.properties.revisionMode = wizardContext.containerApp?.revisionsMode;
-
-    ext.branchDataProvider.refresh();
-    ext.outputChannel.appendLog(localize('finishCommandExecution', '--------Finished deploying workspace project to container app "{0}"--------', wizardContext.containerApp?.name));
+    displayNotification(deployWorkspaceProjectResultContext);
 }
 
 function displayNotification(context: DeployWorkspaceProjectContext): void {

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProjectInternal.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProjectInternal.ts
@@ -1,0 +1,257 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { LocationListStep, ResourceGroupCreateStep } from "@microsoft/vscode-azext-azureutils";
+import { AzureWizard, GenericTreeItem, activityInfoIcon, activitySuccessContext, nonNullValueAndProp, type AzureWizardExecuteStep, type AzureWizardPromptStep, type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
+import { ProgressLocation, window } from "vscode";
+import { appProvider, managedEnvironmentsId } from "../../constants";
+import { ext } from "../../extensionVariables";
+import { type ContainerAppItem } from "../../tree/ContainerAppItem";
+import { type ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
+import { createActivityChildContext, createActivityContext } from "../../utils/activity/activityUtils";
+import { getVerifyProvidersStep } from "../../utils/getVerifyProvidersStep";
+import { localize } from "../../utils/localize";
+import { type IContainerAppContext } from "../IContainerAppContext";
+import { ContainerAppCreateStep } from "../createContainerApp/ContainerAppCreateStep";
+import { LogAnalyticsCreateStep } from "../createManagedEnvironment/LogAnalyticsCreateStep";
+import { ManagedEnvironmentCreateStep } from "../createManagedEnvironment/ManagedEnvironmentCreateStep";
+import { ContainerAppUpdateStep } from "../image/imageSource/ContainerAppUpdateStep";
+import { ImageSourceListStep } from "../image/imageSource/ImageSourceListStep";
+import { IngressPromptStep } from "../ingress/IngressPromptStep";
+import { DeployWorkspaceProjectConfirmStep } from "./DeployWorkspaceProjectConfirmStep";
+import { type DeployWorkspaceProjectContext } from "./DeployWorkspaceProjectContext";
+import { DeployWorkspaceProjectSaveSettingsStep } from "./DeployWorkspaceProjectSaveSettingsStep";
+import { ShouldSaveDeploySettingsPromptStep } from "./ShouldSaveDeploySettingsPromptStep";
+import { DefaultResourcesNameStep } from "./getDefaultValues/DefaultResourcesNameStep";
+import { getDefaultContextValues } from "./getDefaultValues/getDefaultContextValues";
+
+export type DeployWorkspaceProjectInternalContext = IContainerAppContext & Partial<DeployWorkspaceProjectContext>;
+
+export interface DeployWorkspaceProjectInternalOptions {
+    /**
+     * Suppress showing the wizard execution through the activity log
+     */
+    suppressActivity?: boolean;
+    /**
+     * Suppress any [resource] confirmation prompts
+     */
+    suppressConfirmation?: boolean;
+    /**
+     * Suppress the creation of a container app (last potential resource creation step in the process)
+     */
+    suppressContainerAppCreation?: boolean;
+    /**
+     * Suppress loading progress notification
+     */
+    suppressProgress?: boolean;
+    /**
+     * Suppress the default wizard [prompting] title
+     */
+    suppressWizardTitle?: boolean;
+}
+
+export async function deployWorkspaceProjectInternal(
+    context: DeployWorkspaceProjectInternalContext,
+    item: ContainerAppItem | ManagedEnvironmentItem | undefined,
+    options: DeployWorkspaceProjectInternalOptions
+): Promise<DeployWorkspaceProjectContext> {
+
+    ext.outputChannel.appendLog(
+        wrapWithDashFormatting(localize('initCommandExecution', 'Initializing deploy workspace project'))
+    );
+
+    let activityContext: Partial<ExecuteActivityContext>;
+    if (options.suppressActivity) {
+        activityContext = { suppressNotification: true };
+    } else {
+        activityContext = await createActivityContext();
+        activityContext.activityChildren = [];
+    }
+
+    // Show loading indicator while we configure default values
+    let defaultContextValues: Partial<DeployWorkspaceProjectContext> | undefined;
+    await window.withProgress({
+        location: ProgressLocation.Notification,
+        cancellable: false,
+        title: options.suppressProgress ?
+            undefined :
+            localize('loadingWorkspaceTitle', 'Loading workspace project deployment configurations...')
+    }, async () => {
+        defaultContextValues = await getDefaultContextValues(context, item);
+    });
+
+    const wizardContext: DeployWorkspaceProjectContext = {
+        ...context,
+        ...activityContext,
+        ...defaultContextValues,
+    };
+
+    const promptSteps: AzureWizardPromptStep<DeployWorkspaceProjectContext>[] = [
+        new DeployWorkspaceProjectConfirmStep(!!options.suppressConfirmation),
+        new DefaultResourcesNameStep()
+    ];
+
+    const executeSteps: AzureWizardExecuteStep<DeployWorkspaceProjectContext>[] = [
+        new DeployWorkspaceProjectSaveSettingsStep()
+    ];
+
+    // Resource group
+    if (wizardContext.resourceGroup) {
+        wizardContext.telemetry.properties.existingResourceGroup = 'true';
+
+        const resourceGroupName: string = nonNullValueAndProp(wizardContext.resourceGroup, 'name');
+
+        wizardContext.activityChildren?.push(
+            new GenericTreeItem(undefined, {
+                contextValue: createActivityChildContext(['useExistingResourceGroup', activitySuccessContext]),
+                label: localize('useResourceGroup', 'Using resource group "{0}"', resourceGroupName),
+                iconPath: activityInfoIcon
+            })
+        );
+
+        await LocationListStep.setLocation(wizardContext, wizardContext.resourceGroup.location);
+        ext.outputChannel.appendLog(localize('usingResourceGroup', 'Using resource group "{0}".', resourceGroupName));
+    } else {
+        wizardContext.telemetry.properties.existingResourceGroup = 'false';
+        executeSteps.push(new ResourceGroupCreateStep());
+    }
+
+    // Managed environment
+    if (wizardContext.managedEnvironment) {
+        wizardContext.telemetry.properties.existingEnvironment = 'true';
+
+        const managedEnvironmentName: string = nonNullValueAndProp(wizardContext.managedEnvironment, 'name');
+
+        wizardContext.activityChildren?.push(
+            new GenericTreeItem(undefined, {
+                contextValue: createActivityChildContext(['useExistingManagedEnvironment', activitySuccessContext]),
+                label: localize('useManagedEnvironment', 'Using container apps environment "{0}"', managedEnvironmentName),
+                iconPath: activityInfoIcon
+            })
+        );
+
+        if (!LocationListStep.hasLocation(wizardContext)) {
+            await LocationListStep.setLocation(wizardContext, wizardContext.managedEnvironment.location);
+        }
+
+        ext.outputChannel.appendLog(localize('usingManagedEnvironment', 'Using container apps environment "{0}".', managedEnvironmentName));
+    } else {
+        wizardContext.telemetry.properties.existingEnvironment = 'false';
+
+        executeSteps.push(
+            new LogAnalyticsCreateStep(),
+            new ManagedEnvironmentCreateStep()
+        );
+    }
+
+    // Azure Container Registry
+    if (wizardContext.registry) {
+        wizardContext.telemetry.properties.existingRegistry = 'true';
+
+        const registryName: string = nonNullValueAndProp(wizardContext.registry, 'name');
+
+        wizardContext.activityChildren?.push(
+            new GenericTreeItem(undefined, {
+                contextValue: createActivityChildContext(['useExistingAcr', activitySuccessContext]),
+                label: localize('useAcr', 'Using container registry "{0}"', registryName),
+                iconPath: activityInfoIcon
+            })
+        );
+
+        ext.outputChannel.appendLog(localize('usingAcr', 'Using Azure Container Registry "{0}".', registryName));
+    } else {
+        // ImageSourceListStep can already handle this creation logic
+        wizardContext.telemetry.properties.existingRegistry = 'false';
+    }
+
+    // Container app
+    if (wizardContext.containerApp) {
+        wizardContext.telemetry.properties.existingContainerApp = 'true';
+
+        const containerAppName: string = nonNullValueAndProp(wizardContext.containerApp, 'name');
+
+        executeSteps.push(new ContainerAppUpdateStep());
+
+        wizardContext.activityChildren?.push(
+            new GenericTreeItem(undefined, {
+                contextValue: createActivityChildContext(['useExistingContainerApp', activitySuccessContext]),
+                label: localize('useContainerApp', 'Using container app "{0}"', containerAppName),
+                iconPath: activityInfoIcon
+            })
+        );
+
+        ext.outputChannel.appendLog(localize('usingContainerApp', 'Using container app "{0}".', containerAppName));
+
+        if (!LocationListStep.hasLocation(wizardContext)) {
+            await LocationListStep.setLocation(wizardContext, wizardContext.containerApp.location);
+        }
+    } else {
+        wizardContext.telemetry.properties.existingContainerApp = 'false';
+
+        if (!options.suppressContainerAppCreation) {
+            executeSteps.push(new ContainerAppCreateStep());
+        }
+    }
+
+    promptSteps.push(
+        new ImageSourceListStep(),
+        new IngressPromptStep(),
+    );
+
+    // Verify providers
+    executeSteps.push(getVerifyProvidersStep<DeployWorkspaceProjectContext>());
+
+    // Location
+    if (LocationListStep.hasLocation(wizardContext)) {
+        wizardContext.telemetry.properties.existingLocation = 'true';
+        ext.outputChannel.appendLog(localize('useLocation', 'Using location "{0}".', (await LocationListStep.getLocation(wizardContext)).name));
+    } else {
+        wizardContext.telemetry.properties.existingLocation = 'false';
+        LocationListStep.addProviderForFiltering(wizardContext, appProvider, managedEnvironmentsId);
+        LocationListStep.addStep(wizardContext, promptSteps);
+    }
+
+    // Save deploy settings
+    promptSteps.push(new ShouldSaveDeploySettingsPromptStep());
+
+    const wizard: AzureWizard<DeployWorkspaceProjectContext> = new AzureWizard(wizardContext, {
+        title: options.suppressWizardTitle ?
+            undefined :
+            localize('deployWorkspaceProjectTitle', 'Deploy workspace project to a container app'),
+        promptSteps,
+        executeSteps,
+        showLoadingPrompt: true
+    });
+
+    await wizard.prompt();
+
+    if (!options.suppressActivity) {
+        wizardContext.activityTitle = localize('deployWorkspaceProjectActivityTitle', 'Deploy workspace project to container app "{0}"', wizardContext.containerApp?.name || wizardContext.newContainerAppName);
+    }
+
+    ext.outputChannel.appendLog(
+        wrapWithDashFormatting(localize('beginCommandExecution', 'Deploying workspace project'))
+    );
+
+    await wizard.execute();
+
+    wizardContext.telemetry.properties.revisionMode = wizardContext.containerApp?.revisionsMode;
+
+    ext.outputChannel.appendLog(
+        wrapWithDashFormatting(localize('finishCommandExecution', 'Finished deploying workspace project'))
+    );
+
+    ext.branchDataProvider.refresh();
+
+    return wizardContext;
+}
+
+/**
+ * Wrap a string with dashes to make key text more easily visible
+ * @example "--------hello-world--------"
+ */
+function wrapWithDashFormatting(text: string): string {
+    return `--------${text}--------`;
+}

--- a/src/commands/deployWorkspaceProject/getDefaultValues/getDefaultContextValues.ts
+++ b/src/commands/deployWorkspaceProject/getDefaultValues/getDefaultContextValues.ts
@@ -8,8 +8,6 @@ import { parseAzureResourceId } from "@microsoft/vscode-azext-azureutils";
 import { nonNullValue, type ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
 import { ImageSource } from "../../../constants";
 import { ext } from "../../../extensionVariables";
-import { type SetTelemetryProps } from "../../../telemetry/SetTelemetryProps";
-import { type DeployWorkspaceProjectTelemetryProps as TelemetryProps } from "../../../telemetry/commandTelemetryProps";
 import { ContainerAppItem } from "../../../tree/ContainerAppItem";
 import { ManagedEnvironmentItem } from "../../../tree/ManagedEnvironmentItem";
 import { localize } from "../../../utils/localize";
@@ -22,7 +20,7 @@ import { getDefaultContainerAppsResources } from "./getDefaultContainerAppsResou
 import { getWorkspaceProjectPaths } from "./getWorkspaceProjectPaths";
 
 export async function getDefaultContextValues(
-    context: ISubscriptionActionContext & SetTelemetryProps<TelemetryProps>,
+    context: ISubscriptionActionContext & Partial<DeployWorkspaceProjectContext>,
     item?: ContainerAppItem | ManagedEnvironmentItem
 ): Promise<Partial<DeployWorkspaceProjectContext>> {
     const { rootFolder, dockerfilePath } = await getWorkspaceProjectPaths(context);

--- a/src/utils/activity/ExecuteActivityOutputStepBase.ts
+++ b/src/utils/activity/ExecuteActivityOutputStepBase.ts
@@ -25,7 +25,7 @@ export interface ExecuteActivityOutputOptions {
 /**
  * An execute activity base step (wrapper) that automatically handles displaying activity children and/or output log messages on success or fail
  */
-export abstract class ExecuteActivityOutputStepBase<T extends IActionContext & ExecuteActivityContext> extends AzureWizardExecuteStep<T> {
+export abstract class ExecuteActivityOutputStepBase<T extends IActionContext & Partial<ExecuteActivityContext>> extends AzureWizardExecuteStep<T> {
     abstract priority: number;
     protected options: ExecuteActivityOutputOptions = {};
 


### PR DESCRIPTION
Add internal implementation which will be shared by the API command and the normal version of the command.

Helps to decouple this implementation before setting up the API in this PR:
https://github.com/microsoft/vscode-azurecontainerapps/pull/578