### PR TITLE
Convert errors to use `GenericParentTreeItem` and add more specific context values

### DIFF
--- a/src/commands/createContainerApp/ContainerAppCreateStep.ts
+++ b/src/commands/createContainerApp/ContainerAppCreateStep.ts
@@ -5,7 +5,7 @@
 
 import { KnownActiveRevisionsMode, type ContainerAppsAPIClient, type Ingress } from "@azure/arm-appcontainers";
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { containerAppsWebProvider } from "../../constants";
 import { ContainerAppItem } from "../../tree/ContainerAppItem";
@@ -69,7 +69,7 @@ export class ContainerAppCreateStep extends ExecuteActivityOutputStepBase<Create
     protected createSuccessOutput(context: CreateContainerAppContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['containerAppCreateStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['containerAppCreateStepSuccessItem', activitySuccessContext]),
                 label: localize('createContainerApp', 'Create container app "{0}"', context.newContainerAppName),
                 iconPath: activitySuccessIcon
             }),
@@ -79,8 +79,8 @@ export class ContainerAppCreateStep extends ExecuteActivityOutputStepBase<Create
 
     protected createFailOutput(context: CreateContainerAppContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['containerAppCreateStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['containerAppCreateStepFailItem', activityFailContext]),
                 label: localize('createContainerApp', 'Create container app "{0}"', context.newContainerAppName),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
+++ b/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../utils/activity/ExecuteActivityOutputStepBase";
 import { createActivityChildContext } from "../../utils/activity/activityUtils";
@@ -35,7 +35,7 @@ export class LogAnalyticsCreateStep extends ExecuteActivityOutputStepBase<IManag
     protected createSuccessOutput(context: IManagedEnvironmentContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['logAnalyticsCreateStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['logAnalyticsCreateStepSuccessItem', activitySuccessContext]),
                 label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newManagedEnvironmentName),
                 iconPath: activitySuccessIcon
             }),
@@ -45,8 +45,8 @@ export class LogAnalyticsCreateStep extends ExecuteActivityOutputStepBase<IManag
 
     protected createFailOutput(context: IManagedEnvironmentContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['logAnalyticsCreateStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['logAnalyticsCreateStepFailItem', activityFailContext]),
                 label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newManagedEnvironmentName),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
+++ b/src/commands/createManagedEnvironment/ManagedEnvironmentCreateStep.ts
@@ -5,7 +5,7 @@
 
 import { type ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { getResourceGroupFromId, LocationListStep } from "@microsoft/vscode-azext-azureutils";
-import { activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, GenericTreeItem } from "@microsoft/vscode-azext-utils";
+import { activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, GenericParentTreeItem, GenericTreeItem } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { managedEnvironmentsAppProvider } from "../../constants";
 import { createActivityChildContext } from "../../utils/activity/activityUtils";
@@ -68,7 +68,7 @@ export class ManagedEnvironmentCreateStep extends ExecuteActivityOutputStepBase<
     protected createSuccessOutput(context: IManagedEnvironmentContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['managedEnvironmentCreateStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['managedEnvironmentCreateStepSuccessItem', activitySuccessContext]),
                 label: localize('createManagedEnvironment', 'Create container apps environment "{0}"', context.newManagedEnvironmentName),
                 iconPath: activitySuccessIcon
             }),
@@ -78,8 +78,8 @@ export class ManagedEnvironmentCreateStep extends ExecuteActivityOutputStepBase<
 
     protected createFailOutput(context: IManagedEnvironmentContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['managedEnvironmentCreateStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['managedEnvironmentCreateStepFailItem', activityFailContext]),
                 label: localize('createManagedEnvironment', 'Create container apps environment "{0}"', context.newManagedEnvironmentName),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/deployWorkspaceProject/DeployWorkspaceProjectSaveSettingsStep.ts
+++ b/src/commands/deployWorkspaceProject/DeployWorkspaceProjectSaveSettingsStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { relativeSettingsFilePath } from "../../constants";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../utils/activity/ExecuteActivityOutputStepBase";
@@ -54,7 +54,7 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
         context.telemetry.properties.didSaveSettings = 'false';
 
         return {
-            item: new GenericParentTreeItem(undefined, {
+            item: new GenericTreeItem(undefined, {
                 contextValue: createActivityChildContext(['dwpSaveSettingsStepFailItem', activityFailContext]),
                 label: saveSettingsLabel,
                 iconPath: activityFailIcon

--- a/src/commands/deployWorkspaceProject/DeployWorkspaceProjectSaveSettingsStep.ts
+++ b/src/commands/deployWorkspaceProject/DeployWorkspaceProjectSaveSettingsStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { relativeSettingsFilePath } from "../../constants";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../utils/activity/ExecuteActivityOutputStepBase";
@@ -42,7 +42,7 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
 
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['deployWorkspaceProjectSaveSettingsStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['dwpSaveSettingsStepSuccessItem', activitySuccessContext]),
                 label: saveSettingsLabel,
                 iconPath: activitySuccessIcon
             }),
@@ -54,8 +54,8 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
         context.telemetry.properties.didSaveSettings = 'false';
 
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['deployWorkspaceProjectSaveSettingsStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['dwpSaveSettingsStepFailItem', activityFailContext]),
                 label: saveSettingsLabel,
                 iconPath: activityFailIcon
             }),

--- a/src/commands/deployWorkspaceProject/deployWorkspaceProjectInternal.ts
+++ b/src/commands/deployWorkspaceProject/deployWorkspaceProjectInternal.ts
@@ -105,7 +105,7 @@ export async function deployWorkspaceProjectInternal(
 
         wizardContext.activityChildren?.push(
             new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingResourceGroup', activitySuccessContext]),
+                contextValue: createActivityChildContext(['useExistingResourceGroupInfoItem', activitySuccessContext]),
                 label: localize('useResourceGroup', 'Using resource group "{0}"', resourceGroupName),
                 iconPath: activityInfoIcon
             })
@@ -126,7 +126,7 @@ export async function deployWorkspaceProjectInternal(
 
         wizardContext.activityChildren?.push(
             new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingManagedEnvironment', activitySuccessContext]),
+                contextValue: createActivityChildContext(['useExistingManagedEnvironmentInfoItem', activitySuccessContext]),
                 label: localize('useManagedEnvironment', 'Using container apps environment "{0}"', managedEnvironmentName),
                 iconPath: activityInfoIcon
             })
@@ -154,7 +154,7 @@ export async function deployWorkspaceProjectInternal(
 
         wizardContext.activityChildren?.push(
             new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingAcr', activitySuccessContext]),
+                contextValue: createActivityChildContext(['useExistingAcrInfoItem', activitySuccessContext]),
                 label: localize('useAcr', 'Using container registry "{0}"', registryName),
                 iconPath: activityInfoIcon
             })
@@ -176,7 +176,7 @@ export async function deployWorkspaceProjectInternal(
 
         wizardContext.activityChildren?.push(
             new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['useExistingContainerApp', activitySuccessContext]),
+                contextValue: createActivityChildContext(['useExistingContainerAppInfoItem', activitySuccessContext]),
                 label: localize('useContainerApp', 'Using container app "{0}"', containerAppName),
                 iconPath: activityInfoIcon
             })

--- a/src/commands/image/imageSource/ContainerAppUpdateStep.ts
+++ b/src/commands/image/imageSource/ContainerAppUpdateStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { ext } from "../../../extensionVariables";
 import { getContainerEnvelopeWithSecrets, type ContainerAppModel } from "../../../tree/ContainerAppItem";
@@ -50,7 +50,7 @@ export class ContainerAppUpdateStep<T extends ImageSourceContext> extends Execut
     protected createSuccessOutput(context: T): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['containerAppUpdateStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['containerAppUpdateStepSuccessItem', activitySuccessContext]),
                 label: localize('updateContainerAppLabel', 'Update container app "{0}"', context.containerApp?.name),
                 iconPath: activitySuccessIcon
             }),
@@ -60,8 +60,8 @@ export class ContainerAppUpdateStep<T extends ImageSourceContext> extends Execut
 
     protected createFailOutput(context: T): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['containerAppUpdateStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['containerAppUpdateStepFailItem', activityFailContext]),
                 label: localize('updateContainerAppLabel', 'Update container app "{0}"', context.containerApp?.name),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/image/imageSource/EnvironmentVariablesListStep.ts
+++ b/src/commands/image/imageSource/EnvironmentVariablesListStep.ts
@@ -67,7 +67,7 @@ export class EnvironmentVariablesListStep extends AzureWizardPromptStep<Environm
         if (setEnvironmentVariableOption !== SetEnvironmentVariableOption.ProvideFile) {
             context.activityChildren?.push(
                 new GenericTreeItem(undefined, {
-                    contextValue: createActivityChildContext(['environmentVariablesListStep', setEnvironmentVariableOption, activitySuccessContext]),
+                    contextValue: createActivityChildContext(['environmentVariablesListStepSuccessItem', setEnvironmentVariableOption, activitySuccessContext]),
                     label: localize('skipEnvVarsLabel',
                         'Skip environment variable configuration' +
                         (setEnvironmentVariableOption === SetEnvironmentVariableOption.NoDotEnv ? ' (no .env files found)' : '')
@@ -85,7 +85,7 @@ export class EnvironmentVariablesListStep extends AzureWizardPromptStep<Environm
         } else {
             context.activityChildren?.push(
                 new GenericTreeItem(undefined, {
-                    contextValue: createActivityChildContext(['environmentVariablesListStep', setEnvironmentVariableOption, activitySuccessContext]),
+                    contextValue: createActivityChildContext(['environmentVariablesListStepSuccessItem', setEnvironmentVariableOption, activitySuccessContext]),
                     label: localize('saveEnvVarsLabel', 'Save environment variable configuration'),
                     iconPath: activitySuccessIcon
                 })

--- a/src/commands/image/imageSource/buildImageInAzure/BuildImageStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/BuildImageStep.ts
@@ -72,7 +72,7 @@ export class BuildImageStep extends ExecuteActivityOutputStepBase<BuildImageInAz
     }
 
     protected createFailOutput(context: BuildImageInAzureImageSourceContext): ExecuteActivityOutput {
-        let loadMoreChildrenImpl: (() => Promise<AzExtTreeItem[]>) = () => Promise.resolve([]);
+        let loadMoreChildrenImpl: (() => Promise<AzExtTreeItem[]>) | undefined;
         if (this.acrBuildError) {
             loadMoreChildrenImpl = () => {
                 const buildImageLogsItem = new GenericTreeItem(undefined, {

--- a/src/commands/image/imageSource/buildImageInAzure/RunStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/RunStep.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { type DockerBuildRequest as AcrDockerBuildRequest } from "@azure/arm-containerregistry";
-import { AzExtFsExtra, GenericTreeItem, activityFailContext, activityFailIcon } from "@microsoft/vscode-azext-utils";
+import { AzExtFsExtra, GenericParentTreeItem, activityFailContext, activityFailIcon } from "@microsoft/vscode-azext-utils";
 import * as path from 'path';
 import { type Progress } from "vscode";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../../../utils/activity/ExecuteActivityOutputStepBase";
@@ -49,8 +49,8 @@ export class RunStep extends ExecuteActivityOutputStepBase<BuildImageInAzureImag
 
     protected createFailOutput(context: BuildImageInAzureImageSourceContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['runStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['runStepFailItem', activityFailContext]),
                 label: localize('runLabel', 'Build image "{0}" in registry "{1}"', context.imageName, context.registryName),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -22,12 +22,13 @@ export class UploadSourceCodeStep extends ExecuteActivityOutputStepBase<BuildIma
     private _sourceFilePath: string;
 
     protected async executeCore(context: BuildImageInAzureImageSourceContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        context.registryName = nonNullValue(context.registry?.name);
-        context.resourceGroupName = getResourceGroupFromId(nonNullValue(context.registry?.id));
-        context.client = await createContainerRegistryManagementClient(context);
         /* relative path of src folder from rootFolder and what gets deployed */
         this._sourceFilePath = path.dirname(path.relative(context.rootFolder.uri.path, context.dockerfilePath));
         context.telemetry.properties.sourceDepth = this._sourceFilePath === '.' ? '0' : String(this._sourceFilePath.split(path.sep).length);
+
+        context.registryName = nonNullValue(context.registry?.name);
+        context.resourceGroupName = getResourceGroupFromId(nonNullValue(context.registry?.id));
+        context.client = await createContainerRegistryManagementClient(context);
 
         const uploading: string = localize('uploadingSourceCode', 'Uploading source code...', this._sourceFilePath);
         progress.report({ message: uploading });

--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { getResourceGroupFromId } from '@microsoft/vscode-azext-azureutils';
-import { AzExtFsExtra, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullValue } from '@microsoft/vscode-azext-utils';
+import { AzExtFsExtra, GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullValue } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { type Progress } from 'vscode';
 import { fse } from '../../../../node/fs-extra';
@@ -57,7 +57,7 @@ export class UploadSourceCodeStep extends ExecuteActivityOutputStepBase<BuildIma
     protected createSuccessOutput(context: BuildImageInAzureImageSourceContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['uploadSourceCodeStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['uploadSourceCodeStepSuccessItem', activitySuccessContext]),
                 label: localize('uploadSourceCodeLabel', 'Upload source code from "{1}" directory to registry "{0}"', context.registry?.name, this._sourceFilePath),
                 iconPath: activitySuccessIcon
             }),
@@ -67,8 +67,8 @@ export class UploadSourceCodeStep extends ExecuteActivityOutputStepBase<BuildIma
 
     protected createFailOutput(context: BuildImageInAzureImageSourceContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['uploadSourceCodeStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['uploadSourceCodeStepFailItem', activityFailContext]),
                 label: localize('uploadSourceCodeLabel', 'Upload source code from "{1}" directory to registry "{0}"', context.registry?.name, this._sourceFilePath),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryCreateStep.ts
+++ b/src/commands/image/imageSource/containerRegistry/acr/createAcr/RegistryCreateStep.ts
@@ -5,7 +5,7 @@
 
 import { type ContainerRegistryManagementClient } from "@azure/arm-containerregistry";
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../../../../../utils/activity/ExecuteActivityOutputStepBase";
 import { createActivityChildContext } from "../../../../../../utils/activity/activityUtils";
@@ -38,7 +38,7 @@ export class RegistryCreateStep extends ExecuteActivityOutputStepBase<CreateAcrC
     protected createSuccessOutput(context: CreateAcrContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['registryCreateStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['registryCreateStepSuccessItem', activitySuccessContext]),
                 label: localize('createRegistryLabel', 'Create container registry "{0}"', context.newRegistryName),
                 iconPath: activitySuccessIcon
             }),
@@ -48,8 +48,8 @@ export class RegistryCreateStep extends ExecuteActivityOutputStepBase<CreateAcrC
 
     protected createFailOutput(context: CreateAcrContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['registryCreateStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['registryCreateStepFailItem', activityFailContext]),
                 label: localize('createRegistryLabel', 'Create container registry "{0}"', context.newRegistryName),
                 iconPath: activityFailIcon
             }),

--- a/src/commands/ingress/IngressPromptStep.ts
+++ b/src/commands/ingress/IngressPromptStep.ts
@@ -73,7 +73,7 @@ export async function tryConfigureIngressUsingDockerfile(context: IngressContext
     if (!context.containerApp) {
         context.activityChildren?.push(
             new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['ingressPromptStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['ingressPromptStepSuccessItem', activitySuccessContext]),
                 label: context.enableIngress ?
                     localize('ingressEnableLabel', 'Enable ingress on port {0} (from Dockerfile configuration)', context.targetPort) :
                     localize('ingressDisableLabel', 'Disable ingress (from Dockerfile configuration)'),

--- a/src/commands/ingress/enableIngress/EnableIngressStep.ts
+++ b/src/commands/ingress/enableIngress/EnableIngressStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type Ingress } from "@azure/arm-appcontainers";
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { GenericParentTreeItem, GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../../utils/activity/ExecuteActivityOutputStepBase";
 import { createActivityChildContext } from "../../../utils/activity/activityUtils";
@@ -42,7 +42,7 @@ export class EnableIngressStep extends ExecuteActivityOutputStepBase<IngressBase
     protected createSuccessOutput(context: IngressBaseContext): ExecuteActivityOutput {
         return {
             item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['enableIngressStep', activitySuccessContext]),
+                contextValue: createActivityChildContext(['enableIngressStepSuccessItem', activitySuccessContext]),
                 label: localize('enableIngressLabel', 'Enable ingress on port {0} for container app "{1}"', context.targetPort, context.containerApp?.name),
                 iconPath: activitySuccessIcon
             }),
@@ -52,8 +52,8 @@ export class EnableIngressStep extends ExecuteActivityOutputStepBase<IngressBase
 
     protected createFailOutput(context: IngressBaseContext): ExecuteActivityOutput {
         return {
-            item: new GenericTreeItem(undefined, {
-                contextValue: createActivityChildContext(['enableIngressStep', activityFailContext]),
+            item: new GenericParentTreeItem(undefined, {
+                contextValue: createActivityChildContext(['enableIngressStepFailItem', activityFailContext]),
                 label: localize('enableIngressLabel', 'Enable ingress on port {0} for container app "{1}"', context.targetPort, context.containerApp?.name),
                 iconPath: activityFailIcon
             }),


### PR DESCRIPTION
Update activity log error items to use `GenericParentTreeItem` so that any additional error messages can be automatically appended as a child of the step that threw it.

Example:
![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/a0b059a9-3907-4fe5-b900-3084c8b7424e)
