### PR TITLE
Automatically remove the `--platform` flag from the Dockerfile on deployment

### DIFF
--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -110,12 +110,12 @@ export class UploadSourceCodeStep<T extends BuildImageInAzureImageSourceContext>
         let loadMoreChildrenImpl: (() => Promise<AzExtTreeItem[]>) | undefined;
         if (this._customDockerfileDirPath) {
             loadMoreChildrenImpl = () => {
-                const removePlatformSuccessItem = new GenericTreeItem(undefined, {
-                    contextValue: createActivityChildContext(['removePlatformSuccessItem']),
+                const removePlatformFlagItem = new GenericTreeItem(undefined, {
+                    contextValue: createActivityChildContext(['removePlatformFlagItem']),
                     label: localize('removePlatformFlag', 'Remove unsupported ACR "--platform" flag'),
                     iconPath: new ThemeIcon('dash', new ThemeColor('terminal.ansiWhite')),
                 });
-                return Promise.resolve([removePlatformSuccessItem]);
+                return Promise.resolve([removePlatformFlagItem]);
             };
         }
 

--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -60,7 +60,7 @@ export class UploadSourceCodeStep<T extends BuildImageInAzureImageSourceContext>
                 await AzExtFsExtra.deleteResource(this._customDockerfileDirPath, { recursive: true });
             } catch {
                 // Swallow error, don't halt the deploy process just because we couldn't delete the temp files, provide a warning instead
-                ext.outputChannel.appendLog(localize('errorDeletingTempFiles', 'Warning: Could not remove some of the following temporary files: "{0}", "{1}", try removing these manually later.', tempTarFilePath, this._customDockerfileDirPath));
+                ext.outputChannel.appendLog(localize('errorDeletingTempFiles', 'Warning: Could not remove some of the following temporary files: "{0}", "{1}". Try removing these manually at a later time.', tempTarFilePath, this._customDockerfileDirPath));
             }
         } else {
             await tar.c({ cwd: source, gzip: true, file: context.tarFilePath }, items.map(i => path.relative(source, i.fsPath)));

--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -87,7 +87,7 @@ export class UploadSourceCodeStep<T extends BuildImageInAzureImageSourceContext>
             return;
         }
 
-        ext.outputChannel.appendLog(localize('removePlatformFlag', 'Detected a --platform flag in the Dockerfile. This flag is not supported in ACR. Attemping to provide a Dockerfile with the --platform flag removed.'));
+        ext.outputChannel.appendLog(localize('removePlatformFlag', 'Detected a --platform flag in the Dockerfile. This flag is not supported in ACR. Attempting to provide a Dockerfile with the --platform flag removed.'));
         dockerfileContent = dockerfileContent.replace(platformRegex, '$1$2');
 
         const customDockerfileDirPath: string = path.join(tmpdir(), randomUUID());

--- a/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
+++ b/src/commands/image/imageSource/buildImageInAzure/UploadSourceCodeStep.ts
@@ -87,7 +87,7 @@ export class UploadSourceCodeStep<T extends BuildImageInAzureImageSourceContext>
      */
     private async buildCustomDockerfileIfNecessary(context: T): Promise<void> {
         // Build a custom Dockerfile if it has ACR's unsupported `--platform` flag
-        // See: https://github.com/microsoft/vscode-azurecontainerapps/issues/598
+        // See: https://github.com/Azure/acr/issues/697
         const platformRegex: RegExp = /^(FROM.*)\s--platform=\S+(.*)$/gm;
         let dockerfileContent: string = await AzExtFsExtra.readFile(context.dockerfilePath);
 


### PR DESCRIPTION
Closes #598 

ACR does not support the `--platform` flag and will automatically error out if it detects this flag.  They have an open issue for it, but we have no idea when it will be addressed and enough people are running into it that we have been asked to help address this on our end.

Updated activity log:
![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/ea695787-1e58-4d67-ba58-93b376589e26)

Big thanks and credit out to Anthony Chu for helping us come up with the bulk of the core logic for custom Dockerfile replacement! :)