### PR TITLE
Fix default name validation logic for `deployWorkspaceProject`

### DIFF
--- a/src/commands/createContainerApp/ContainerAppNameStep.ts
+++ b/src/commands/createContainerApp/ContainerAppNameStep.ts
@@ -17,7 +17,7 @@ export class ContainerAppNameStep extends AzureWizardPromptStep<CreateContainerA
         const prompt: string = localize('containerAppNamePrompt', 'Enter a container app name.');
         context.newContainerAppName = (await context.ui.showInputBox({
             prompt,
-            validateInput: this.validateInput,
+            validateInput: ContainerAppNameStep.validateInput,
             asyncValidationTask: (name: string) => this.validateNameAvailable(context, name)
         })).trim();
 
@@ -28,7 +28,7 @@ export class ContainerAppNameStep extends AzureWizardPromptStep<CreateContainerA
         return !context.containerApp && !context.newContainerAppName;
     }
 
-    private validateInput(name: string | undefined): string | undefined {
+    public static validateInput(name: string | undefined): string | undefined {
         name = name ? name.trim() : '';
 
         const { minLength, maxLength } = { minLength: 1, maxLength: 32 };

--- a/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
@@ -66,18 +66,15 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
             (!context.containerApp && !context.newContainerAppName);
     }
 
-    private validateInput(name: string | undefined): string | undefined {
-        name ??= '';
-
+    private validateInput(name: string = ''): string | undefined {
         // No symbols are allowed for ACR - we will strip out any offending characters from the base name, but still need to ensure this version has an appropriate length
         const nameWithoutSymbols: string = name.replace(/[^a-z0-9]+/g, '');
         if (!validateUtils.isValidLength(nameWithoutSymbols, 5, 20)) {
             return localize('invalidLength', 'The alphanumeric portion of the name must be least 5 characters but no more than 20 characters.');
         }
 
-        const symbols: string = '-';
-        if (!validateUtils.isLowerCaseAlphanumericWithSymbols(name, symbols, false /** canSymbolsRepeat */)) {
-            return validateUtils.getInvalidLowerCaseAlphanumericWithSymbolsMessage(symbols);
+        if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
+            return localize('invalidNameFormat', `A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.`);
         }
 
         return undefined;

--- a/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
@@ -67,6 +67,8 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
     }
 
     private validateInput(name: string = ''): string | undefined {
+        name = name.trim();
+
         // No symbols are allowed for ACR - we will strip out any offending characters from the base name, but still need to ensure this version has an appropriate length
         const nameWithoutSymbols: string = name.replace(/[^a-z0-9]+/g, '');
         if (!validateUtils.isValidLength(nameWithoutSymbols, 5, 20)) {

--- a/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/getDefaultValues/DefaultResourcesNameStep.ts
@@ -75,11 +75,9 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
             return localize('invalidLength', 'The alphanumeric portion of the name must be least 5 characters but no more than 20 characters.');
         }
 
-        if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
-            return localize('invalidNameFormat', `A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.`);
-        }
-
-        return undefined;
+        // Container app names currently have the strictest name formatting logic at the time of writing this
+        // Todo: https://github.com/microsoft/vscode-azurecontainerapps/issues/603
+        return ContainerAppNameStep.validateInput(name);
     }
 
     protected async validateNameAvailability(context: DeployWorkspaceProjectContext, name: string): Promise<string | undefined> {


### PR DESCRIPTION
Don't allow names to start with a number.

Closes #596 