### PR TITLE
Add a unique ID field to deployment configurations

### DIFF
--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/DeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/DeploymentConfiguration.ts
@@ -9,7 +9,7 @@ import { type WorkspaceFolder } from "vscode";
 import { type ContainerAppModel } from "../../../tree/ContainerAppItem";
 
 export interface DeploymentConfiguration {
-    configurationId?: string;
+    configurationIdx?: number;
     rootFolder?: WorkspaceFolder;
     dockerfilePath?: string;
     srcPath?: string;

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/DeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/DeploymentConfiguration.ts
@@ -9,6 +9,7 @@ import { type WorkspaceFolder } from "vscode";
 import { type ContainerAppModel } from "../../../tree/ContainerAppItem";
 
 export interface DeploymentConfiguration {
+    configurationId?: string;
     rootFolder?: WorkspaceFolder;
     dockerfilePath?: string;
     srcPath?: string;

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
@@ -16,7 +16,7 @@ export class DeploymentConfigurationListStep extends AzureWizardPromptStep<Works
             return;
         }
 
-        const pick: IAzureQuickPickItem<(DeploymentConfigurationSettings & { configurationIdx?: number }) | undefined> = await context.ui.showQuickPick(this.getPicks(deploymentConfigurations), {
+        const pick = await context.ui.showQuickPick(this.getPicks(deploymentConfigurations), {
             placeHolder: localize('chooseDeployConfigurationSetting', 'Select an app configuration to deploy'),
             suppressPersistence: true,
         });

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
@@ -16,10 +16,13 @@ export class DeploymentConfigurationListStep extends AzureWizardPromptStep<Works
             return;
         }
 
-        context.deploymentConfigurationSettings = (await context.ui.showQuickPick(this.getPicks(deploymentConfigurations), {
+        const pick: IAzureQuickPickItem<(DeploymentConfigurationSettings & { configurationIdx?: number }) | undefined> = await context.ui.showQuickPick(this.getPicks(deploymentConfigurations), {
             placeHolder: localize('chooseDeployConfigurationSetting', 'Select an app configuration to deploy'),
             suppressPersistence: true,
-        })).data;
+        });
+
+        context.deploymentConfigurationSettings = pick.data;
+        context.configurationIdx = pick.data?.configurationIdx;
     }
 
     public shouldPrompt(context: WorkspaceDeploymentConfigurationContext): boolean {
@@ -39,13 +42,13 @@ export class DeploymentConfigurationListStep extends AzureWizardPromptStep<Works
         };
     }
 
-    private getPicks(deploymentConfigurations: DeploymentConfigurationSettings[]): IAzureQuickPickItem<DeploymentConfigurationSettings | undefined>[] {
-        const picks: IAzureQuickPickItem<DeploymentConfigurationSettings | undefined>[] = deploymentConfigurations.map(deploymentConfiguration => {
+    private getPicks(deploymentConfigurations: DeploymentConfigurationSettings[]): IAzureQuickPickItem<(DeploymentConfigurationSettings & { configurationIdx?: number }) | undefined>[] {
+        const picks: IAzureQuickPickItem<DeploymentConfigurationSettings | undefined>[] = deploymentConfigurations.map((deploymentConfiguration, i) => {
             return {
                 label: deploymentConfiguration.label ?? localize('unnamedApp', 'Unnamed app'),
                 // Show the container app name as the description by default, unless the label has the same name
                 description: deploymentConfiguration.label === deploymentConfiguration.containerApp ? undefined : deploymentConfiguration.containerApp,
-                data: deploymentConfiguration
+                data: { ...deploymentConfiguration, configurationIdx: i }
             };
         });
 

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
@@ -30,7 +30,7 @@ export async function getWorkspaceDeploymentConfiguration(context: IContainerApp
     await wizard.execute();
 
     return {
-        configurationId: wizardContext.deploymentConfigurationSettings?.id,
+        configurationIdx: wizardContext.configurationIdx,
         rootFolder: wizardContext.rootFolder,
         dockerfilePath: wizardContext.dockerfilePath,
         srcPath: wizardContext.srcPath,

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
@@ -30,6 +30,7 @@ export async function getWorkspaceDeploymentConfiguration(context: IContainerApp
     await wizard.execute();
 
     return {
+        configurationId: wizardContext.deploymentConfigurationSettings?.id,
         rootFolder: wizardContext.rootFolder,
         dockerfilePath: wizardContext.dockerfilePath,
         srcPath: wizardContext.srcPath,

--- a/src/commands/deployWorkspaceProject/settings/DeployWorkspaceProjectSettingsV2.ts
+++ b/src/commands/deployWorkspaceProject/settings/DeployWorkspaceProjectSettingsV2.ts
@@ -8,6 +8,7 @@ export interface DeployWorkspaceProjectSettingsV2 {
 }
 
 export interface DeploymentConfigurationSettings {
+    id?: string;
     label?: string;
     type?: string;
     dockerfilePath?: string;

--- a/src/commands/deployWorkspaceProject/settings/DeployWorkspaceProjectSettingsV2.ts
+++ b/src/commands/deployWorkspaceProject/settings/DeployWorkspaceProjectSettingsV2.ts
@@ -8,7 +8,6 @@ export interface DeployWorkspaceProjectSettingsV2 {
 }
 
 export interface DeploymentConfigurationSettings {
-    id?: string;
     label?: string;
     type?: string;
     dockerfilePath?: string;


### PR DESCRIPTION
I think adding a UUID for each deployment configuration will give us an easy way to save and overwrite settings.  I'm not sure that there are any other settings that exist that we can check and expect to be unique each and every time.