### PR TITLE
Use existing env variables when updating container app if "skipped"

### DIFF
--- a/src/commands/image/imageSource/EnvironmentVariablesListStep.ts
+++ b/src/commands/image/imageSource/EnvironmentVariablesListStep.ts
@@ -44,11 +44,15 @@ export class EnvironmentVariablesListStep extends AzureWizardPromptStep<Environm
 
     private async selectEnvironmentSettings(context: EnvironmentVariablesContext): Promise<DotenvParseOutput | undefined> {
         const placeHolder: string = localize('setEnvVar', 'Select a {0} file to set the environment variables for the container instance', '.env');
+        // since we only allow one container, we can assume that we want the first container's env settings
+        const existingData: DotenvParseOutput | undefined = context.containerApp?.template?.containers?.[0].env as DotenvParseOutput | undefined;
+        const skipLabel: string | undefined = existingData ? localize('useExisting', 'Use existing configuration') : undefined;
+
         const envFileFsPath: string | undefined = await selectWorkspaceFile(context, placeHolder,
-            { filters: { 'env file': ['env', 'env.*'] }, allowSkip: true }, allEnvFilesGlobPattern);
+            { filters: { 'env file': ['env', 'env.*'] }, allowSkip: true, skipLabel }, allEnvFilesGlobPattern);
 
         if (!envFileFsPath) {
-            return undefined;
+            return existingData;
         }
 
         const data = await AzExtFsExtra.readFile(envFileFsPath);

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -17,6 +17,10 @@ interface SelectWorkspaceFileOptions extends OpenDialogOptions {
      */
     allowSkip?: boolean;
     /**
+     * Optional label for the 'skipForNow' option; will default to 'Skip for now' if not provided
+     */
+    skipLabel?: string;
+    /**
      * If searching through the workspace file path returns only one matching result, automatically return its path without additional prompting
      */
     autoSelectIfOne?: boolean;
@@ -68,9 +72,10 @@ export async function selectWorkspaceFile(
 
         quickPicks.push(browseItem);
 
+        const label = options.skipLabel ?? localize('skipForNow', '$(clock) Skip for now');
         if (options.allowSkip) {
             quickPicks.push({
-                label: localize('skipForNow', '$(clock) Skip for now'),
+                label,
                 description: '',
                 data: skipForNow
             });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurecontainerapps/issues/451

Note that this only applies for `updateContainerApp` since `deployWorkspace` leverages `getDefaultContextValue` which sets `context.environmentVariables` to `[ ]` if it doesn't detect an `.env` file.

I didn't change this behavior because I figured that we will be altering `deployWorkspace`'s behavior; specifically we'll be looking at an `envPath` setting.