### PR TITLE
Add fallback defaulting logic for ACRs within `deployWorkspaceProjectInternal`

### DIFF
--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
@@ -34,7 +34,7 @@ export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWor
         }
 
         // Prioritize trying to find a registry in the same resource group
-        // Otherwise, just find the first available registry
+        // Otherwise, just use the first available registry
         context.registry = registryInSameResourceGroup || registry;
     }
 

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
@@ -15,7 +15,7 @@ export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWor
     public async execute(context: DeployWorkspaceProjectInternalContext): Promise<void> {
         const registries: Registry[] = await AcrListStep.getRegistries(context);
 
-        let resourceGroupRegistry: Registry | undefined;
+        let registryInSameResourceGroup: Registry | undefined;
         let registry: Registry | undefined;
 
         for (const r of registries) {
@@ -24,7 +24,7 @@ export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWor
             }
 
             if (parseAzureResourceId(r.id).resourceGroup === context.resourceGroup?.name) {
-                resourceGroupRegistry = r;
+                registryInSameResourceGroup = r;
                 break;
             }
 
@@ -33,7 +33,9 @@ export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWor
             }
         }
 
-        context.registry = resourceGroupRegistry || registry;
+        // Prioritize trying to find a registry in the same resource group
+        // Otherwise, just find the first available registry
+        context.registry = registryInSameResourceGroup || registry;
     }
 
     public shouldExecute(context: DeployWorkspaceProjectInternalContext): boolean {

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
@@ -30,6 +30,10 @@ export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWor
 
             if (!registry) {
                 registry = r;
+
+                if (!context.resourceGroup) {
+                    break;
+                }
             }
         }
 

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/TryUseExistingRegistryStep.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type Registry } from "@azure/arm-containerregistry";
+import { parseAzureResourceId } from "@microsoft/vscode-azext-azureutils";
+import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
+import { AcrListStep } from "../../../image/imageSource/containerRegistry/acr/AcrListStep";
+import { type DeployWorkspaceProjectInternalContext } from "../DeployWorkspaceProjectInternalContext";
+
+export class TryUseExistingRegistryStep extends AzureWizardExecuteStep<DeployWorkspaceProjectInternalContext> {
+    public priority: number = 200;  /** Todo: Figure out a good priority level */
+
+    public async execute(context: DeployWorkspaceProjectInternalContext): Promise<void> {
+        const registries: Registry[] = await AcrListStep.getRegistries(context);
+
+        let resourceGroupRegistry: Registry | undefined;
+        let registry: Registry | undefined;
+
+        for (const r of registries) {
+            if (!r.id) {
+                continue;
+            }
+
+            if (parseAzureResourceId(r.id).resourceGroup === context.resourceGroup?.name) {
+                resourceGroupRegistry = r;
+                break;
+            }
+
+            if (!registry) {
+                registry = r;
+            }
+        }
+
+        context.registry = resourceGroupRegistry || registry;
+    }
+
+    public shouldExecute(context: DeployWorkspaceProjectInternalContext): boolean {
+        return !context.registry;
+    }
+}

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/getStartingConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/getStartingConfiguration.ts
@@ -12,6 +12,7 @@ import { AcrBuildSupportedOS } from "../../../image/imageSource/buildImageInAzur
 import { RootFolderStep } from "../../../image/imageSource/buildImageInAzure/RootFolderStep";
 import { type DeployWorkspaceProjectInternalContext } from "../DeployWorkspaceProjectInternalContext";
 import { DwpManagedEnvironmentListStep } from "./DwpManagedEnvironmentListStep";
+import { TryUseExistingRegistryStep } from "./TryUseExistingRegistryStep";
 import { getResourcesFromContainerAppHelper, getResourcesFromManagedEnvironmentHelper } from "./containerAppsResourceHelpers";
 
 export async function getStartingConfiguration(context: DeployWorkspaceProjectInternalContext): Promise<Partial<DeployWorkspaceProjectInternalContext>> {
@@ -24,7 +25,7 @@ export async function getStartingConfiguration(context: DeployWorkspaceProjectIn
             new DwpManagedEnvironmentListStep()
         ],
         executeSteps: [
-            // Todo: Add ACR defaulting step
+            new TryUseExistingRegistryStep()
         ]
     });
 


### PR DESCRIPTION
The internal logic presents the last bastion of hope for our users to find a suitable ACR without prompting.  We should do everything we can to assist them out on the cloudy battlefield ☁⚔️