### PR TITLE
Improve type safety and reorganize resource verification files

### DIFF
--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/getTreeItemDeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/getTreeItemDeploymentConfiguration.ts
@@ -9,7 +9,7 @@ import { ManagedEnvironmentItem } from "../../../tree/ManagedEnvironmentItem";
 import { type IContainerAppContext } from "../../IContainerAppContext";
 import { RootFolderStep } from "../../image/imageSource/buildImageInAzure/RootFolderStep";
 import { type DeploymentConfiguration } from "./DeploymentConfiguration";
-import { TryUseExistingWorkspaceRegistryStep } from "./workspace/TryUseExistingWorkspaceRegistryStep";
+import { TryUseExistingWorkspaceRegistryStep } from "./workspace/azureResources/TryUseExistingWorkspaceRegistryStep";
 
 type TreeItemDeploymentConfigurationContext = IContainerAppContext & DeploymentConfiguration;
 

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/DeploymentConfigurationListStep.ts
@@ -7,11 +7,11 @@ import { AzureWizardPromptStep, nonNullProp, type IAzureQuickPickItem, type IWiz
 import { localize } from "../../../../utils/localize";
 import { type DeploymentConfigurationSettings } from "../../settings/DeployWorkspaceProjectSettingsV2";
 import { dwpSettingUtilsV2 } from "../../settings/dwpSettingUtilsV2";
-import { ContainerAppVerifyStep } from "./ContainerAppVerifyStep";
-import { ContainerRegistryVerifyStep } from "./ContainerRegistryVerifyStep";
 import { FilePathsVerifyStep } from "./FilePathsVerifyStep";
-import { ResourceGroupVerifyStep } from "./ResourceGroupVerifyStep";
 import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
+import { ContainerAppVerifyStep } from "./azureResources/ContainerAppVerifyStep";
+import { ContainerRegistryVerifyStep } from "./azureResources/ContainerRegistryVerifyStep";
+import { ResourceGroupVerifyStep } from "./azureResources/ResourceGroupVerifyStep";
 
 export class DeploymentConfigurationListStep extends AzureWizardPromptStep<WorkspaceDeploymentConfigurationContext> {
     public async prompt(context: WorkspaceDeploymentConfigurationContext): Promise<void> {

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/AzureResourceVerifyStepBase.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/AzureResourceVerifyStepBase.ts
@@ -5,22 +5,22 @@
 
 import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
-import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../../../utils/activity/ExecuteActivityOutputStepBase";
-import { createActivityChildContext } from "../../../../utils/activity/activityUtils";
-import { localize } from "../../../../utils/localize";
-import { type DeploymentConfigurationSettings } from "../../settings/DeployWorkspaceProjectSettingsV2";
-import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
+import { ExecuteActivityOutputStepBase, type ExecuteActivityOutput } from "../../../../../utils/activity/ExecuteActivityOutputStepBase";
+import { createActivityChildContext } from "../../../../../utils/activity/activityUtils";
+import { localize } from "../../../../../utils/localize";
+import { type DeploymentConfigurationSettings } from "../../../settings/DeployWorkspaceProjectSettingsV2";
+import { type WorkspaceDeploymentConfigurationContext } from "../WorkspaceDeploymentConfigurationContext";
 
 export abstract class AzureResourceVerifyStepBase extends ExecuteActivityOutputStepBase<WorkspaceDeploymentConfigurationContext> {
     public abstract priority: number;
 
     protected abstract resourceType: 'resource group' | 'container app' | 'container registry';
-    protected abstract deploymentSettingsKey: string;
-    protected abstract contextKey: string;
+    protected abstract deploymentSettingsKey: keyof DeploymentConfigurationSettings;
+    protected abstract contextKey: keyof WorkspaceDeploymentConfigurationContext;
 
     protected async executeCore(context: WorkspaceDeploymentConfigurationContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         this.options.shouldSwallowError = true;
-        progress.report({ message: localize(`verifyingResourceType`, 'Verifying {0}...', this.resourceType) });
+        progress.report({ message: localize(`verifyingAzureResources`, 'Verifying Azure resources...') });
 
         const settings: DeploymentConfigurationSettings | undefined = context.deploymentConfigurationSettings;
         if (!settings?.[this.deploymentSettingsKey]) {

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/AzureResourceVerifyStepBase.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/AzureResourceVerifyStepBase.ts
@@ -20,7 +20,7 @@ export abstract class AzureResourceVerifyStepBase extends ExecuteActivityOutputS
 
     protected async executeCore(context: WorkspaceDeploymentConfigurationContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         this.options.shouldSwallowError = true;
-        progress.report({ message: localize(`verifyingAzureResources`, 'Verifying Azure resources...') });
+        progress.report({ message: localize(`verifyingResourceType`, 'Verifying {0}...', this.resourceType) });
 
         const settings: DeploymentConfigurationSettings | undefined = context.deploymentConfigurationSettings;
         if (!settings?.[this.deploymentSettingsKey]) {

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ContainerAppVerifyStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ContainerAppVerifyStep.ts
@@ -5,17 +5,17 @@
 
 import { type ContainerApp, type ContainerAppsAPIClient } from "@azure/arm-appcontainers";
 import { nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
-import { ContainerAppItem } from "../../../../tree/ContainerAppItem";
-import { createContainerAppsAPIClient } from "../../../../utils/azureClients";
+import { ContainerAppItem } from "../../../../../tree/ContainerAppItem";
+import { createContainerAppsAPIClient } from "../../../../../utils/azureClients";
+import { type WorkspaceDeploymentConfigurationContext } from "../WorkspaceDeploymentConfigurationContext";
 import { AzureResourceVerifyStepBase } from "./AzureResourceVerifyStepBase";
-import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
 
 export class ContainerAppVerifyStep extends AzureResourceVerifyStepBase {
     public priority: number = 205;  /** Todo: Figure out a good priority level */
 
     protected resourceType = 'container app' as const;
-    protected deploymentSettingsKey: string = 'containerApp';
-    protected contextKey: string = 'containerApp';
+    protected deploymentSettingsKey = 'containerApp' as const;
+    protected contextKey = 'containerApp' as const;
 
     protected async verifyResource(context: WorkspaceDeploymentConfigurationContext): Promise<void> {
         const client: ContainerAppsAPIClient = await createContainerAppsAPIClient(context);

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ContainerRegistryVerifyStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ContainerRegistryVerifyStep.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type Registry } from "@azure/arm-containerregistry";
-import { AcrListStep } from "../../../image/imageSource/containerRegistry/acr/AcrListStep";
+import { AcrListStep } from "../../../../image/imageSource/containerRegistry/acr/AcrListStep";
+import { type WorkspaceDeploymentConfigurationContext } from "../WorkspaceDeploymentConfigurationContext";
 import { AzureResourceVerifyStepBase } from "./AzureResourceVerifyStepBase";
-import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
 
 export class ContainerRegistryVerifyStep extends AzureResourceVerifyStepBase {
     public priority: number = 210;  /** Todo: Figure out a good priority level */
 
     protected resourceType = 'container registry' as const;
-    protected deploymentSettingsKey: string = 'containerRegistry';
-    protected contextKey: string = 'registry';
+    protected deploymentSettingsKey = 'containerRegistry' as const;
+    protected contextKey = 'registry' as const;
 
     protected async verifyResource(context: WorkspaceDeploymentConfigurationContext): Promise<void> {
         const registries: Registry[] = await AcrListStep.getRegistries(context);

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ResourceGroupVerifyStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/ResourceGroupVerifyStep.ts
@@ -5,15 +5,15 @@
 
 import { type ResourceGroup } from "@azure/arm-resources";
 import { ResourceGroupListStep } from "@microsoft/vscode-azext-azureutils";
+import { type WorkspaceDeploymentConfigurationContext } from "../WorkspaceDeploymentConfigurationContext";
 import { AzureResourceVerifyStepBase } from "./AzureResourceVerifyStepBase";
-import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
 
 export class ResourceGroupVerifyStep extends AzureResourceVerifyStepBase {
     public priority: number = 200;  /** Todo: Figure out a good priority level */
 
     protected resourceType = 'resource group' as const;
-    protected deploymentSettingsKey: string = 'resourceGroup';
-    protected contextKey: string = 'resourceGroup';
+    protected deploymentSettingsKey = 'resourceGroup' as const;
+    protected contextKey = 'resourceGroup' as const;
 
     protected async verifyResource(context: WorkspaceDeploymentConfigurationContext): Promise<void> {
         const resourceGroups: ResourceGroup[] = await ResourceGroupListStep.getResourceGroups(context);

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/TryUseExistingWorkspaceRegistryStep.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/azureResources/TryUseExistingWorkspaceRegistryStep.ts
@@ -6,12 +6,12 @@
 import { type Registry } from "@azure/arm-containerregistry";
 import { AzureWizardExecuteStep, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
-import { ext } from "../../../../extensionVariables";
-import { localize } from "../../../../utils/localize";
-import { AcrListStep } from "../../../image/imageSource/containerRegistry/acr/AcrListStep";
-import { type DeploymentConfigurationSettings } from "../../settings/DeployWorkspaceProjectSettingsV2";
-import { dwpSettingUtilsV2 } from "../../settings/dwpSettingUtilsV2";
-import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
+import { ext } from "../../../../../extensionVariables";
+import { localize } from "../../../../../utils/localize";
+import { AcrListStep } from "../../../../image/imageSource/containerRegistry/acr/AcrListStep";
+import { type DeploymentConfigurationSettings } from "../../../settings/DeployWorkspaceProjectSettingsV2";
+import { dwpSettingUtilsV2 } from "../../../settings/dwpSettingUtilsV2";
+import { type WorkspaceDeploymentConfigurationContext } from "../WorkspaceDeploymentConfigurationContext";
 
 export class TryUseExistingWorkspaceRegistryStep extends AzureWizardExecuteStep<WorkspaceDeploymentConfigurationContext> {
     public priority: number = 220;  /** Todo: Figure out a good priority level */

--- a/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
+++ b/src/commands/deployWorkspaceProject/deploymentConfiguration/workspace/getWorkspaceDeploymentConfiguration.ts
@@ -10,8 +10,8 @@ import { type IContainerAppContext } from "../../../IContainerAppContext";
 import { RootFolderStep } from "../../../image/imageSource/buildImageInAzure/RootFolderStep";
 import { type DeploymentConfiguration } from "../DeploymentConfiguration";
 import { DeploymentConfigurationListStep } from "./DeploymentConfigurationListStep";
-import { TryUseExistingWorkspaceRegistryStep } from "./TryUseExistingWorkspaceRegistryStep";
 import { type WorkspaceDeploymentConfigurationContext } from "./WorkspaceDeploymentConfigurationContext";
+import { TryUseExistingWorkspaceRegistryStep } from "./azureResources/TryUseExistingWorkspaceRegistryStep";
 
 export async function getWorkspaceDeploymentConfiguration(context: IContainerAppContext): Promise<DeploymentConfiguration> {
     const wizardContext: WorkspaceDeploymentConfigurationContext = Object.assign(context, {


### PR DESCRIPTION
- Use `keyof` for key properties
- Reorganize `azureResource/` files