### PR TITLE
Try to add default name suffixes to resources in `deployWorkspaceProjectInternal`

### DIFF
--- a/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
+++ b/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
@@ -13,7 +13,7 @@ export interface IManagedEnvironmentContext extends ISubscriptionActionContext, 
     subscription: AzureSubscription;
 
     newManagedEnvironmentName?: string;
-    newLogAnalyticsWorkspaceName?: string;
+    newLogAnalyticsWorkspaceName?: string;  // This isn't normally populated by a name step, but we still allow this to be prepopulated
     logAnalyticsWorkspace?: Workspace;
 
     // created when the wizard is done executing

--- a/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
+++ b/src/commands/createManagedEnvironment/IManagedEnvironmentContext.ts
@@ -13,6 +13,7 @@ export interface IManagedEnvironmentContext extends ISubscriptionActionContext, 
     subscription: AzureSubscription;
 
     newManagedEnvironmentName?: string;
+    newLogAnalyticsWorkspaceName?: string;
     logAnalyticsWorkspace?: Workspace;
 
     // created when the wizard is done executing

--- a/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
+++ b/src/commands/createManagedEnvironment/LogAnalyticsCreateStep.ts
@@ -19,7 +19,7 @@ export class LogAnalyticsCreateStep extends ExecuteActivityOutputStepBase<IManag
     protected async executeCore(context: IManagedEnvironmentContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const opClient = await createOperationalInsightsManagementClient(context);
         const resourceGroup = nonNullProp(context, 'resourceGroup');
-        const workspaceName = nonNullProp(context, 'newManagedEnvironmentName');
+        const workspaceName = context.newLogAnalyticsWorkspaceName || nonNullProp(context, 'newManagedEnvironmentName');
 
         const creating: string = localize('creatingLogAnalyticsWorkspace', 'Creating log analytics workspace...');
         progress.report({ message: creating });
@@ -36,10 +36,10 @@ export class LogAnalyticsCreateStep extends ExecuteActivityOutputStepBase<IManag
         return {
             item: new GenericTreeItem(undefined, {
                 contextValue: createActivityChildContext(['logAnalyticsCreateStepSuccessItem', activitySuccessContext]),
-                label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newManagedEnvironmentName),
+                label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newLogAnalyticsWorkspaceName || context.newManagedEnvironmentName),
                 iconPath: activitySuccessIcon
             }),
-            message: localize('createLogAnalyticsWorkspaceSuccess', 'Created log analytics workspace "{0}".', context.newManagedEnvironmentName)
+            message: localize('createLogAnalyticsWorkspaceSuccess', 'Created log analytics workspace "{0}".', context.newLogAnalyticsWorkspaceName || context.newManagedEnvironmentName)
         };
     }
 
@@ -47,10 +47,10 @@ export class LogAnalyticsCreateStep extends ExecuteActivityOutputStepBase<IManag
         return {
             item: new GenericParentTreeItem(undefined, {
                 contextValue: createActivityChildContext(['logAnalyticsCreateStepFailItem', activityFailContext]),
-                label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newManagedEnvironmentName),
+                label: localize('createWorkspace', 'Create log analytics workspace "{0}"', context.newLogAnalyticsWorkspaceName || context.newManagedEnvironmentName),
                 iconPath: activityFailIcon
             }),
-            message: localize('createLogAnalyticsWorkspaceFail', 'Failed to create log analytics workspace "{0}".', context.newManagedEnvironmentName)
+            message: localize('createLogAnalyticsWorkspaceFail', 'Failed to create log analytics workspace "{0}".', context.newLogAnalyticsWorkspaceName || context.newManagedEnvironmentName)
         };
     }
 }

--- a/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
@@ -34,7 +34,7 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
             asyncValidationTask: (name: string) => this.validateNameAvailability(context, name)
         })).trim();
 
-        ext.outputChannel.appendLog(localize('usingResourceName', 'User provided the new resource name "{0}" as the default for resource creation.', resourceName))
+        ext.outputChannel.appendLog(localize('usingResourceName', 'User provided the new resource name "{0}" as the base for resource creation.', resourceName))
 
         const suffixNamesAvailable: boolean = await this.checkSuffixNamesAvailable(context, resourceName);
 

--- a/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
@@ -39,7 +39,7 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
         const suffixNamesAvailable: boolean = await this.checkSuffixNamesAvailable(context, resourceName);
 
         if (suffixNamesAvailable) {
-            ext.outputChannel.appendLog(localize('suffixNamesAvailable', `Verified that the provided names with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.) are also available. Automatically attaching a suffix to each resource name.`));
+            ext.outputChannel.appendLog(localize('suffixNamesAvailable', `Verified that the provided names with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.) are also available. Automatically attaching suffixes to each resource name.`));
         } else {
             ext.outputChannel.appendLog(localize('suffixNamesUnavailable', `Unable to verify provided name with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.). Defaulting all resources to the original name provided.`));
         }

--- a/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
@@ -38,6 +38,12 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
 
         const suffixNamesAvailable: boolean = await this.checkSuffixNamesAvailable(context, resourceName);
 
+        if (suffixNamesAvailable) {
+            ext.outputChannel.appendLog(localize('suffixNamesAvailable', `Verified that the provided names with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.) are also available. Automatically attaching a suffix to each resource name.`));
+        } else {
+            ext.outputChannel.appendLog(localize('suffixNamesUnavailable', `Unable to verify provided name with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.). Defaulting all resources to the original name provided.`));
+        }
+
         if (!context.managedEnvironment) {
             context.newManagedEnvironmentName = suffixNamesAvailable ? resourceName + managedEnvironmentSuffix : resourceName;
             context.newLogAnalyticsWorkspaceName = suffixNamesAvailable ? resourceName + logAnalyticsSuffix : resourceName;

--- a/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DefaultResourcesNameStep.ts
@@ -38,12 +38,6 @@ export class DefaultResourcesNameStep extends AzureWizardPromptStep<DeployWorksp
 
         const suffixNamesAvailable: boolean = await this.checkSuffixNamesAvailable(context, resourceName);
 
-        if (suffixNamesAvailable) {
-            ext.outputChannel.appendLog(localize('suffixNamesAvailable', `Verified that the provided names with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.) are also available. Automatically attaching suffixes to each resource name.`));
-        } else {
-            ext.outputChannel.appendLog(localize('suffixNamesUnavailable', `Unable to verify provided name with attached resource suffixes (e.g. ${resourceName + '-rg'}, ${resourceName + '-ca'}, etc.). Defaulting all resources to the original name provided.`));
-        }
-
         if (!context.managedEnvironment) {
             context.newManagedEnvironmentName = suffixNamesAvailable ? resourceName + managedEnvironmentSuffix : resourceName;
             context.newLogAnalyticsWorkspaceName = suffixNamesAvailable ? resourceName + logAnalyticsSuffix : resourceName;

--- a/src/commands/deployWorkspaceProject/internal/DeployWorkspaceProjectSaveSettingsStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DeployWorkspaceProjectSaveSettingsStep.ts
@@ -28,7 +28,7 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
         const deploymentConfigurations: DeploymentConfigurationSettings[] = await dwpSettingUtilsV2.getWorkspaceDeploymentConfigurations(rootFolder) ?? [];
 
         const deploymentConfiguration: DeploymentConfigurationSettings = {
-            label: context.configurationIdx !== undefined && deploymentConfigurations?.[context.configurationIdx].label || removeCaSuffixIfNecessary(nonNullValueAndProp(context.containerApp, 'name')),
+            label: context.configurationIdx !== undefined && deploymentConfigurations?.[context.configurationIdx].label || removeCaSuffixIfExists(nonNullValueAndProp(context.containerApp, 'name')),
             type: 'AcrDockerBuildRequest',
             dockerfilePath: path.relative(rootFolder.uri.fsPath, nonNullProp(context, 'dockerfilePath')),
             srcPath: path.relative(rootFolder.uri.fsPath, context.srcPath || rootFolder.uri.fsPath) || ".",
@@ -78,6 +78,6 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
     }
 }
 
-function removeCaSuffixIfNecessary(caName: string): string {
+function removeCaSuffixIfExists(caName: string): string {
     return caName.endsWith(containerAppSuffix) ? caName.slice(0, -containerAppSuffix.length) : caName;
 }

--- a/src/commands/deployWorkspaceProject/internal/DeployWorkspaceProjectSaveSettingsStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/DeployWorkspaceProjectSaveSettingsStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { GenericTreeItem, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import * as path from "path";
 import { type Progress, type WorkspaceFolder } from "vscode";
 import { relativeSettingsFilePath } from "../../../constants";
@@ -12,6 +12,7 @@ import { createActivityChildContext } from "../../../utils/activity/activityUtil
 import { localize } from "../../../utils/localize";
 import { type DeploymentConfigurationSettings } from "../settings/DeployWorkspaceProjectSettingsV2";
 import { dwpSettingUtilsV2 } from "../settings/dwpSettingUtilsV2";
+import { containerAppSuffix } from "./DefaultResourcesNameStep";
 import { type DeployWorkspaceProjectInternalContext } from "./DeployWorkspaceProjectInternalContext";
 
 const saveSettingsLabel: string = localize('saveSettingsLabel', 'Save deployment settings to workspace "{0}"', relativeSettingsFilePath);
@@ -27,7 +28,7 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
         const deploymentConfigurations: DeploymentConfigurationSettings[] = await dwpSettingUtilsV2.getWorkspaceDeploymentConfigurations(rootFolder) ?? [];
 
         const deploymentConfiguration: DeploymentConfigurationSettings = {
-            label: context.configurationIdx !== undefined && deploymentConfigurations?.[context.configurationIdx].label || context.containerApp?.name,
+            label: context.configurationIdx !== undefined && deploymentConfigurations?.[context.configurationIdx].label || removeCaSuffixIfNecessary(nonNullValueAndProp(context.containerApp, 'name')),
             type: 'AcrDockerBuildRequest',
             dockerfilePath: path.relative(rootFolder.uri.fsPath, nonNullProp(context, 'dockerfilePath')),
             srcPath: path.relative(rootFolder.uri.fsPath, context.srcPath || rootFolder.uri.fsPath) || ".",
@@ -75,4 +76,8 @@ export class DeployWorkspaceProjectSaveSettingsStep extends ExecuteActivityOutpu
             message: localize('savedSettingsFail', 'Failed to save deployment settings to workspace "{0}".', relativeSettingsFilePath)
         };
     }
+}
+
+function removeCaSuffixIfNecessary(caName: string): string {
+    return caName.endsWith(containerAppSuffix) ? caName.slice(0, -containerAppSuffix.length) : caName;
 }


### PR DESCRIPTION
If able, will attach suffixes to names (e.g. `-ca`, `-env`, `-rg`, `-log`, etc.)

![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/40250218/ca10c752-e7df-43b5-8480-68fbae860d24)
