### PR TITLE
Find previously deployed to managed environment and recommend them

### DIFF
--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
@@ -26,9 +26,9 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
 
         await this.setRecommendedPicks(context, picks);
         const pick = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
-        context.telemetry.properties.usedRecommendedEnv = pick.description === recommendedPickDescription ? 'true' : 'false';
+        context.telemetry.properties.usedRecommendedEnv = isRecommendedPick(pick) ? 'true' : 'false';
         context.telemetry.properties.recommendedEnvCount =
-            String(picks.reduce((count, p) => count + (p.description === recommendedPickDescription ? 1 : 0), 0));
+            String(picks.reduce((count, pick) => count + (isRecommendedPick(pick) ? 1 : 0), 0));
 
         const managedEnvironment: ManagedEnvironment | undefined = pick.data;
         if (!managedEnvironment) {
@@ -97,18 +97,11 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
             }
         }
 
-        const recommendedPick = (pick: IAzureQuickPickItem<ManagedEnvironment | undefined>): boolean => {
-            if (pick.description === recommendedPickDescription) {
-                return true;
-            }
-
-            return false;
-        };
         // sort the picks by recommendation
         picks.sort((a, b) => {
-            if (recommendedPick(a)) {
+            if (isRecommendedPick(a)) {
                 return -1;
-            } else if (recommendedPick(b)) {
+            } else if (isRecommendedPick(b)) {
                 return 1;
             } else {
                 return 0;
@@ -116,3 +109,5 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
         });
     }
 }
+
+const isRecommendedPick = (pick: IAzureQuickPickItem<ManagedEnvironment | undefined>): boolean => pick.description === recommendedPickDescription;

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
@@ -76,7 +76,6 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
     }
 
     private async setRecommendedPicks(context: DeployWorkspaceProjectInternalContext, picks: IAzureQuickPickItem<ManagedEnvironment | undefined>[]): Promise<void> {
-        const recommendedEnvCount = 0;
         const deploymentConfigurations: DeploymentConfigurationSettings[] | undefined = await dwpSettingUtilsV2.getWorkspaceDeploymentConfigurations(nonNullProp(context, 'rootFolder'));
         if (!deploymentConfigurations?.length) {
             return;
@@ -115,7 +114,5 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
                 return 0;
             }
         });
-
-        context.telemetry.properties.recommendedManagedEnvironmentCount = String(recommendedEnvCount);
     }
 }

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
@@ -13,7 +13,7 @@ import { type DeploymentConfigurationSettings } from "../../settings/DeployWorks
 import { dwpSettingUtilsV2 } from "../../settings/dwpSettingUtilsV2";
 import { type DeployWorkspaceProjectInternalContext } from "../DeployWorkspaceProjectInternalContext";
 
-const recommendedPickDescription: string = localize('recommended', 'Recommended');
+const recommendedPickDescription: string = localize('recommended', '(Recommended)');
 export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployWorkspaceProjectInternalContext> {
     public async prompt(context: DeployWorkspaceProjectInternalContext): Promise<void> {
         const placeHolder: string = localize('selectManagedEnvironment', 'Select a container apps environment');

--- a/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/startingConfiguration/DwpManagedEnvironmentListStep.ts
@@ -26,10 +26,9 @@ export class DwpManagedEnvironmentListStep extends AzureWizardPromptStep<DeployW
 
         await this.setRecommendedPicks(context, picks);
         const pick = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
-        // (recently used) can be in the description of the pick
-        context.telemetry.properties.usedRecommendedEnv = pick.description?.includes(recommendedPickDescription) ? 'true' : 'false';
+        context.telemetry.properties.usedRecommendedEnv = pick.description === recommendedPickDescription ? 'true' : 'false';
         context.telemetry.properties.recommendedEnvCount =
-            String(picks.reduce((count, p) => count + (p.description?.includes(recommendedPickDescription) ? 1 : 0), 0));
+            String(picks.reduce((count, p) => count + (p.description === recommendedPickDescription ? 1 : 0), 0));
 
         const managedEnvironment: ManagedEnvironment | undefined = pick.data;
         if (!managedEnvironment) {

--- a/src/telemetry/deployWorkspaceProjectTelemetryProps.ts
+++ b/src/telemetry/deployWorkspaceProjectTelemetryProps.ts
@@ -31,6 +31,10 @@ export interface DeployWorkspaceProjectInternalTelemetryProps extends AzdTelemet
     hasNewSettings?: 'true' | 'false';  // ShouldSaveDeploySettingsPromptStep
     shouldSaveDeploySettings?: 'true' | 'false';  // ShouldSaveDeploySettingsPromptStep
     didSaveSettings?: 'true' | 'false';  // DeployWorkspaceProjectSaveSettingsStep - we swallow errors here, so log the outcome just in case
+
+    // Recommended Managed Environment
+    recommendedEnvCount?: string; // number casted to string
+    usedRecommendedEnv?: 'true' | 'false';
 }
 
 export interface DeployWorkspaceProjectNotificationTelemetryProps {

--- a/src/telemetry/deployWorkspaceProjectTelemetryProps.ts
+++ b/src/telemetry/deployWorkspaceProjectTelemetryProps.ts
@@ -32,7 +32,7 @@ export interface DeployWorkspaceProjectInternalTelemetryProps extends AzdTelemet
     shouldSaveDeploySettings?: 'true' | 'false';  // ShouldSaveDeploySettingsPromptStep
     didSaveSettings?: 'true' | 'false';  // DeployWorkspaceProjectSaveSettingsStep - we swallow errors here, so log the outcome just in case
 
-    // Recommended Managed Environment
+    // Recommended managed environments
     recommendedEnvCount?: string; // number casted to string
     usedRecommendedEnv?: 'true' | 'false';
 }


### PR DESCRIPTION
I toyed with the idea of using grouping instead of description. Not sure if we want to go that route though in case we started grouping things by resource group or something.

Also `supressedPersistence` because the (recently used) description looks kind of silly with recommended.

![image](https://github.com/microsoft/vscode-azurecontainerapps/assets/5290572/2e60afd9-4e36-418a-b93c-0b0851493823)
