### PR TITLE
Small fixes to ensure backwards compatibility with API

### DIFF
--- a/src/commands/api/deployWorkspaceProjectApi.ts
+++ b/src/commands/api/deployWorkspaceProjectApi.ts
@@ -34,7 +34,7 @@ export async function deployWorkspaceProjectApi(deployWorkspaceProjectOptions: a
             ...subscriptionContext,
             subscription,
             resourceGroup,
-            newManagedEnvironmentName: await verifyNewManagedEnvironmentName({ ...context, ...subscriptionContext }, resourceGroup?.name, resourceGroup?.name),
+            newManagedEnvironmentName: await tryGetNewManagedEnvironmentName({ ...context, ...subscriptionContext }, resourceGroup?.name, resourceGroup?.name),
             rootFolder,
             srcPath: srcPath ? Uri.file(srcPath).fsPath : undefined,
             dockerfilePath: dockerfilePath ? Uri.file(dockerfilePath).fsPath : undefined,
@@ -53,7 +53,7 @@ export async function deployWorkspaceProjectApi(deployWorkspaceProjectOptions: a
     }) ?? {};
 }
 
-async function verifyNewManagedEnvironmentName(context: ISubscriptionActionContext, resourceGroupName?: string, newEnvironmentName?: string): Promise<string | undefined> {
+async function tryGetNewManagedEnvironmentName(context: ISubscriptionActionContext, resourceGroupName?: string, newEnvironmentName?: string): Promise<string | undefined> {
     if (!resourceGroupName || !newEnvironmentName) {
         return undefined;
     }

--- a/src/commands/api/getAzureContainerAppsApiProvider.ts
+++ b/src/commands/api/getAzureContainerAppsApiProvider.ts
@@ -9,7 +9,9 @@ import type * as api from "./vscode-azurecontainerapps.api";
 
 export function getAzureContainerAppsApiProvider(): apiUtils.AzureExtensionApiProvider {
     return createApiProvider([<api.AzureContainerAppsExtensionApi>{
-        apiVersion: '0.0.2',
+        // Todo: Change this to 0.0.2 later.  0.0.2 is backwards compatible anyway so this change should be fine either way.
+        // For some reason it's causing a block on Function side, so just keep it at 0.0.1 until we figure out why
+        apiVersion: '0.0.1',
         deployWorkspaceProject: deployWorkspaceProjectApi
     }]);
 }

--- a/src/commands/deployWorkspaceProject/internal/AppResourcesNameStep.ts
+++ b/src/commands/deployWorkspaceProject/internal/AppResourcesNameStep.ts
@@ -47,6 +47,6 @@ export class AppResourcesNameStep extends AzureWizardPromptStep<DeployWorkspaceP
     }
 
     public shouldPrompt(context: DeployWorkspaceProjectInternalContext): boolean {
-        return !context.containerApp && !context.newContainerAppName && this.suppressContainerAppCreation;
+        return !context.containerApp && !context.newContainerAppName && !this.suppressContainerAppCreation;
     }
 }

--- a/src/commands/deployWorkspaceProject/internal/deployWorkspaceProjectInternal.ts
+++ b/src/commands/deployWorkspaceProject/internal/deployWorkspaceProjectInternal.ts
@@ -87,7 +87,7 @@ export async function deployWorkspaceProjectInternal(
     const promptSteps: AzureWizardPromptStep<DeployWorkspaceProjectInternalContext>[] = [
         new DeployWorkspaceProjectConfirmStep(!!options.suppressConfirmation),
         new SharedResourcesNameStep(),
-        new AppResourcesNameStep()
+        new AppResourcesNameStep(!!options.suppressContainerAppCreation)
     ];
 
     const executeSteps: AzureWizardExecuteStep<DeployWorkspaceProjectInternalContext>[] = [


### PR DESCRIPTION
Also, try to name the managed environment after the resource group automatically if one is supplied