### PR TITLE
Upgrade API version to 1.0.1

### DIFF
--- a/src/commands/api/CHANGELOG.md
+++ b/src/commands/api/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-### 0.0.2
+### 1.0.1
 
 ### Changed
 
 * [[615]](https://github.com/microsoft/vscode-azurecontainerapps/pull/615) Removed ability to set option `ignoreExistingDeploySettings`. This will now happen automatically by default.
 
-## 0.0.1
+## 1.0.0
 * Initial release
 
 ### Added

--- a/src/commands/api/getAzureContainerAppsApiProvider.ts
+++ b/src/commands/api/getAzureContainerAppsApiProvider.ts
@@ -9,9 +9,7 @@ import type * as api from "./vscode-azurecontainerapps.api";
 
 export function getAzureContainerAppsApiProvider(): apiUtils.AzureExtensionApiProvider {
     return createApiProvider([<api.AzureContainerAppsExtensionApi>{
-        // Todo: Change this to 0.0.2 later.  0.0.2 is backwards compatible anyway so this change should be fine either way.
-        // For some reason it's causing a block on Function side, so just keep it at 0.0.1 until we figure out why
-        apiVersion: '0.0.1',
+        apiVersion: '1.0.1',
         deployWorkspaceProject: deployWorkspaceProjectApi
     }]);
 }


### PR DESCRIPTION
We should have just released the API version at 1.0.0 since 0.0.1 does some funky things with semver. The API itself isn't in preview (even if the extensions are) so there's really no reason to be using 0.0.1 anyway.