### PR TITLE
Revert "Upgrade API version to 1.0.1"

### DIFF
--- a/src/commands/api/CHANGELOG.md
+++ b/src/commands/api/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-### 1.0.1
+### 0.0.2
 
 ### Changed
 
 * [[615]](https://github.com/microsoft/vscode-azurecontainerapps/pull/615) Removed ability to set option `ignoreExistingDeploySettings`. This will now happen automatically by default.
 
-## 1.0.0
+## 0.0.1
 * Initial release
 
 ### Added

--- a/src/commands/api/getAzureContainerAppsApiProvider.ts
+++ b/src/commands/api/getAzureContainerAppsApiProvider.ts
@@ -9,7 +9,9 @@ import type * as api from "./vscode-azurecontainerapps.api";
 
 export function getAzureContainerAppsApiProvider(): apiUtils.AzureExtensionApiProvider {
     return createApiProvider([<api.AzureContainerAppsExtensionApi>{
-        apiVersion: '1.0.1',
+        // Todo: Change this to 0.0.2 later.  0.0.2 is backwards compatible anyway so this change should be fine either way.
+        // For some reason it's causing a block on Function side, so just keep it at 0.0.1 until we figure out why
+        apiVersion: '0.0.1',
         deployWorkspaceProject: deployWorkspaceProjectApi
     }]);
 }


### PR DESCRIPTION
Reverts microsoft/vscode-azurecontainerapps#674

We can coordinate a release for Functions and Containers when there's less chaos in the world. Let's just keep the api-version as is for now since it's backwards compatible anyway.