### PR TITLE
Update long running tests check logic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,7 +92,7 @@
                 "MOCHA_timeout": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "v",
                 "NODE_DEBUG": "",
-                "AzCode_EnableLongRunningTestsLocal": "true"
+                "AzCode_EnableLongRunningTestsLocal": ""
             }
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,7 +92,7 @@
                 "MOCHA_timeout": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "v",
                 "NODE_DEBUG": "",
-                "AzCode_UseAzureFederatedCredentials": ""
+                "AzCode_EnableLongRunningTestsLocal": "true"
             }
         },
         {

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -9,10 +9,10 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { ext, registerOnActionStartHandler, registerUIExtensionVariables } from '../extension.bundle';
 
-const longRunningLocalDevelopmentEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_EnableLongRunningTestsLocal || '');
-const longRunningRemoteDevelopmentEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_UseAzureFederatedCredentials || '');
+const longRunningLocalTestsEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_EnableLongRunningTestsLocal || '');
+const longRunningRemoteTestsEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_UseAzureFederatedCredentials || '');
 
-export const longRunningTestsEnabled: boolean = longRunningLocalDevelopmentEnabled || longRunningRemoteDevelopmentEnabled;
+export const longRunningTestsEnabled: boolean = longRunningLocalTestsEnabled || longRunningRemoteTestsEnabled;
 
 // Runs before all tests
 suiteSetup(async function (this: Mocha.Context): Promise<void> {

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -9,7 +9,10 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { ext, registerOnActionStartHandler, registerUIExtensionVariables } from '../extension.bundle';
 
-export const longRunningTestsEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_UseAzureFederatedCredentials || '');
+const longRunningLocalDevelopmentEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_EnableLongRunningTestsLocal || '');
+const longRunningRemoteDevelopmentEnabled: boolean = !/^(false|0)?$/i.test(process.env.AzCode_UseAzureFederatedCredentials || '');
+
+export const longRunningTestsEnabled: boolean = longRunningLocalDevelopmentEnabled || longRunningRemoteDevelopmentEnabled;
 
 // Runs before all tests
 suiteSetup(async function (this: Mocha.Context): Promise<void> {


### PR DESCRIPTION
Now that the new resources update has gone out, I'm seeing that setting the federated credentials environment variable during local testing will try to force resource groups to behave like it's reading from the remote pipeline.

We only want to do this while we are actually in the remote environment.  When in the local environment, we want to bypass that behavior.  I've added a new environment variable for local development and updated the check to help fix this issue.  Now we can distinguish between the two environments and act accordingly.