### PR TITLE
Use main branch of release template

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -2,13 +2,13 @@ trigger: none # Only run this pipeline when manually triggered
 
 resources:
   pipelines:
-    - pipeline: vscode-azurecontainerapps # identifier to use in pipeline resource variables
+    - pipeline: build # identifier to use in pipeline resource variables
       source: \Azure Tools\VSCode\Extensions\vscode-azurecontainerapps # name of the pipeline that produces the artifacts
   repositories:
     - repository: azExtTemplates
       type: github
       name: microsoft/vscode-azuretools
-      ref: alex/release-template
+      ref: main
       endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
 
 variables:
@@ -20,5 +20,5 @@ variables:
 extends:
   template: azure-pipelines/release-extension.yml@azExtTemplates
   parameters:
-    pipelineID: $(resources.pipeline.vscode-azurecontainerapps.pipelineID)
-    runID: $(resources.pipeline.vscode-azurecontainerapps.runID)
+    pipelineID: $(resources.pipeline.build.pipelineID)
+    runID: $(resources.pipeline.build.runID)


### PR DESCRIPTION
Now that we know it works, I merged the templates into main so we need to use the templates on main instead of my dev branch now.