### PR TITLE
Add a better error message when trying to expand an app that isn't provisioned yet

### DIFF
--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -93,7 +93,7 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
                 this.containerApp.name);
 
             if (this.containerApp.provisioningState && this.containerApp.provisioningState !== 'Succeeded') {
-                throw new Error(localize('provisioningError', 'The container app "{0}" and its children cannot be accessed until the app is successfully provisioned.', this._containerApp.name));
+                throw new Error(localize('provisioningError', 'The container app "{0}" cannot be expanded due to its provisioning state of "{1}". Its children cannot be accessed until the app is successfully provisioned.', this._containerApp.name, this.containerApp.provisioningState));
             }
 
             const children: TreeElementBase[] = [];

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -92,6 +92,10 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
                 this.containerApp.id,
                 this.containerApp.name);
 
+            if (this.containerApp.provisioningState && this.containerApp.provisioningState !== 'Succeeded') {
+                throw new Error(localize('provisioningError', 'The container app "{0}" and its related children cannot be accessed until the app is successfully provisioned.', this._containerApp.name));
+            }
+
             const children: TreeElementBase[] = [];
             const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, createSubscriptionContext(this.subscription)]);
 

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -93,7 +93,7 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
                 this.containerApp.name);
 
             if (this.containerApp.provisioningState && this.containerApp.provisioningState !== 'Succeeded') {
-                throw new Error(localize('provisioningError', 'The container app "{0}" cannot be expanded due to its provisioning state of "{1}". Its children cannot be accessed until the app is successfully provisioned.', this._containerApp.name, this.containerApp.provisioningState));
+                throw new Error(localize('provisioningError', 'The container app "{0}" cannot be expanded due to its provisioning state of "{1}". Its children cannot be accessed until the app is successfully provisioned.', this.containerApp.name, this.containerApp.provisioningState));
             }
 
             const children: TreeElementBase[] = [];

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -93,7 +93,7 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
                 this.containerApp.name);
 
             if (this.containerApp.provisioningState && this.containerApp.provisioningState !== 'Succeeded') {
-                throw new Error(localize('provisioningError', 'The container app "{0}" and its related children cannot be accessed until the app is successfully provisioned.', this._containerApp.name));
+                throw new Error(localize('provisioningError', 'The container app "{0}" and its children cannot be accessed until the app is successfully provisioned.', this._containerApp.name));
             }
 
             const children: TreeElementBase[] = [];


### PR DESCRIPTION
From:

![image](https://github.com/user-attachments/assets/aa0e3f6d-dd8f-4839-a209-9a464aefaffb)


To:

![image](https://github.com/user-attachments/assets/e1b7d2f7-9006-4539-813d-f8724e0737a0)
