### PR TITLE
Don't show `editScalingRange` on another `ScaleItem` if a draft item already exists

### DIFF
--- a/src/commands/scaling/scaleRange/editScaleRange.ts
+++ b/src/commands/scaling/scaleRange/editScaleRange.ts
@@ -10,7 +10,7 @@ import { type ScaleItem } from "../../../tree/scaling/ScaleItem";
 import { createActivityContext } from "../../../utils/activityUtils";
 import { localize } from "../../../utils/localize";
 import { pickScale } from "../../../utils/pickItem/pickScale";
-import { getParentResource } from "../../../utils/revisionDraftUtils";
+import { getParentResource, isTemplateItemEditable, throwTemplateItemNotEditable } from "../../../utils/revisionDraftUtils";
 import { type ScaleRangeContext } from "./ScaleRangeContext";
 import { ScaleRangePromptStep } from "./ScaleRangePromptStep";
 import { ScaleRangeUpdateStep } from "./ScaleRangeUpdateStep";
@@ -18,6 +18,10 @@ import { ScaleRangeUpdateStep } from "./ScaleRangeUpdateStep";
 export async function editScaleRange(context: IActionContext, node?: ScaleItem): Promise<void> {
     const item: ScaleItem = node ?? await pickScale(context, { autoSelectDraft: true });
     const { containerApp, revision, subscription } = item;
+
+    if (!isTemplateItemEditable(item)) {
+        throwTemplateItemNotEditable(item);
+    }
 
     const parentResource: ContainerAppModel | Revision = getParentResource(containerApp, revision);
     const scale: Scale = nonNullValueAndProp(parentResource.template, 'scale');

--- a/src/utils/revisionDraftUtils.ts
+++ b/src/utils/revisionDraftUtils.ts
@@ -32,7 +32,7 @@ export function getParentResourceFromItem(item: ContainerAppItem | RevisionsItem
 
 /**
  * Checks to see whether a given container app template item is in an editable state
- * (Template item here refers to any tree item descendant of the following - see 'RevisionItem.getTemplateChildren')
+ * (Template item here refers to any tree item descendant of the RevisionItem - see 'RevisionItem.getTemplateChildren')
  * (The name template originates from the container app envelope's 'template' set of properties which happen to also be tied to each revision)
  */
 export function isTemplateItemEditable(item: RevisionsItemModel): boolean {

--- a/src/utils/revisionDraftUtils.ts
+++ b/src/utils/revisionDraftUtils.ts
@@ -4,8 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KnownActiveRevisionsMode, type Revision } from "@azure/arm-appcontainers";
+import { ext } from "../extensionVariables";
 import { ContainerAppItem, type ContainerAppModel } from "../tree/ContainerAppItem";
+import { RevisionDraftItem } from "../tree/revisionManagement/RevisionDraftItem";
 import { type RevisionsItemModel } from "../tree/revisionManagement/RevisionItem";
+import { localize } from "./localize";
 
 /**
  * Use to always select the correct parent resource model
@@ -25,4 +28,25 @@ export function getParentResourceFromItem(item: ContainerAppItem | RevisionsItem
     } else {
         return item.revision;
     }
+}
+
+/**
+ * Checks to see whether a given container app template item is in an editable state
+ * (Template item here refers to any tree item descendant of the following - see 'RevisionItem.getTemplateChildren')
+ * (The name template originates from the container app envelope's 'template' set of properties which happen to also be tied to each revision)
+ */
+export function isTemplateItemEditable(item: RevisionsItemModel): boolean {
+    // Rule 1: Single revision edits are always okay
+    // Rule 2: If in multiple revisions mode and no draft is in session, revision edits are always okay
+    // Rule 3: If in multiple revisions mode and a draft is in session, do not allow any other edits besides those on the draft item
+    return item.containerApp.revisionsMode === KnownActiveRevisionsMode.Single ||
+        !ext.revisionDraftFileSystem.doesContainerAppsItemHaveRevisionDraft(item) ||
+        RevisionDraftItem.hasDescendant(item);
+}
+
+/**
+ * If a template item is not editable, throw this error to cancel and alert the user
+ */
+export function throwTemplateItemNotEditable(item: RevisionsItemModel) {
+    throw new Error(localize('itemNotEditable', 'Action cannot be performed on revision "{0}" because a draft is currently active.', item.revision.name));
 }


### PR DESCRIPTION
Fix an issue where `editScalingRange` was showing up on other revision items even when a draft node already existed.  In my opinion, it's confusing / doesn't make sense to allow users to try editing other revisions simultaneously when another draft already exists.