### PR TITLE
Change draft deploy pop-up from an informational window to a quick pick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@azure/storage-blob": "^12.4.1",
                 "@microsoft/vscode-azext-azureutils": "^3.1.1",
                 "@microsoft/vscode-azext-github": "^1.0.0",
-                "@microsoft/vscode-azext-utils": "^2.5.7",
+                "@microsoft/vscode-azext-utils": "^2.5.10",
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "buffer": "^6.0.3",
                 "dayjs": "^1.11.3",
@@ -1210,9 +1210,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.7.tgz",
-            "integrity": "sha512-ZZYsASAawR/JhIPeVsplIsN8JK5d3nc2IkIS7RE5AWbbWVtrheCPkS9OoNx+Roal1w3u7Bm0nYJ6eI5NaxnvJw==",
+            "version": "2.5.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.10.tgz",
+            "integrity": "sha512-b+wN2A7eGLilPyVFoV2ICu2t8259Fr8sqSrQsLcjWZL1MsETFe5C/7HWNB3dQjkFZmMGsxcZ5hfTBT2Ukq18mg==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",
@@ -1221,7 +1221,7 @@
                 "html-to-text": "^8.2.0",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
-                "vscode-tas-client": "^0.1.47",
+                "vscode-tas-client": "^0.1.84",
                 "vscode-uri": "^3.0.6"
             },
             "peerDependencies": {
@@ -2603,16 +2603,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/azure-devops-node-api": {
@@ -4480,25 +4470,6 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
             "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
             "dev": true
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/for-each": {
             "version": "0.3.3",
@@ -7269,11 +7240,6 @@
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
             "dev": true
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8281,12 +8247,9 @@
             }
         },
         "node_modules/tas-client": {
-            "version": "0.1.73",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
-            "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
-            "dependencies": {
-                "axios": "^1.6.1"
-            }
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
+            "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
         },
         "node_modules/teex": {
             "version": "1.0.1",
@@ -8922,14 +8885,14 @@
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
         },
         "node_modules/vscode-tas-client": {
-            "version": "0.1.75",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
-            "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
+            "version": "0.1.84",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
+            "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
             "dependencies": {
-                "tas-client": "0.1.73"
+                "tas-client": "0.2.33"
             },
             "engines": {
-                "vscode": "^1.19.1"
+                "vscode": "^1.85.0"
             }
         },
         "node_modules/vscode-uri": {
@@ -10416,9 +10379,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.7.tgz",
-            "integrity": "sha512-ZZYsASAawR/JhIPeVsplIsN8JK5d3nc2IkIS7RE5AWbbWVtrheCPkS9OoNx+Roal1w3u7Bm0nYJ6eI5NaxnvJw==",
+            "version": "2.5.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.10.tgz",
+            "integrity": "sha512-b+wN2A7eGLilPyVFoV2ICu2t8259Fr8sqSrQsLcjWZL1MsETFe5C/7HWNB3dQjkFZmMGsxcZ5hfTBT2Ukq18mg==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",
@@ -10427,7 +10390,7 @@
                 "html-to-text": "^8.2.0",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
-                "vscode-tas-client": "^0.1.47",
+                "vscode-tas-client": "^0.1.84",
                 "vscode-uri": "^3.0.6"
             },
             "dependencies": {
@@ -11541,16 +11504,6 @@
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
             "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
             "dev": true
-        },
-        "axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-            "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "azure-devops-node-api": {
             "version": "11.1.0",
@@ -12961,11 +12914,6 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
             "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
             "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "for-each": {
             "version": "0.3.3",
@@ -15025,11 +14973,6 @@
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
             "dev": true
         },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -15788,12 +15731,9 @@
             }
         },
         "tas-client": {
-            "version": "0.1.73",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
-            "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
-            "requires": {
-                "axios": "^1.6.1"
-            }
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
+            "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
         },
         "teex": {
             "version": "1.0.1",
@@ -16280,11 +16220,11 @@
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
         },
         "vscode-tas-client": {
-            "version": "0.1.75",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
-            "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
+            "version": "0.1.84",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
+            "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
             "requires": {
-                "tas-client": "0.1.73"
+                "tas-client": "0.2.33"
             }
         },
         "vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -799,7 +799,7 @@
         "@azure/storage-blob": "^12.4.1",
         "@microsoft/vscode-azext-azureutils": "^3.1.1",
         "@microsoft/vscode-azext-github": "^1.0.0",
-        "@microsoft/vscode-azext-utils": "^2.5.7",
+        "@microsoft/vscode-azext-utils": "^2.5.10",
         "@microsoft/vscode-azureresources-api": "^2.0.2",
         "buffer": "^6.0.3",
         "dayjs": "^1.11.3",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,7 +4,7 @@
     "containerApps.revealResource": "Reveal Resource",
     "containerApps.description": "An Azure Container Apps extension for Visual Studio Code.",
     "containerApps.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
-    "containerApps.showDraftCommandDeployPopup": "Show an informational deploy pop-up message whenever a draft command is run.",
+    "containerApps.showDraftCommandDeployPopup": "Prompt to deploy revision draft whenever a draft command is run.",
     "containerApps.browse": "Browse",
     "containerApps.createContainerApp": "Create Container App...",
     "containerApps.createContainerAppFromWorkspace": "Create Container App from Workspace...",

--- a/src/commands/revisionDraft/RevisionDraftContext.ts
+++ b/src/commands/revisionDraft/RevisionDraftContext.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type IContainerAppContext } from "../IContainerAppContext";
+
+export interface RevisionDraftContext extends IContainerAppContext {
+    shouldDeployRevisionDraft?: boolean;
+}

--- a/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, type IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
-import { showDraftCommandDeployPopupKey } from "../../constants";
+import { showDraftCommandDeployPopupSetting } from "../../constants";
 import { localize } from "../../utils/localize";
 import { settingUtils } from "../../utils/settingUtils";
 import { type RevisionDraftContext } from "./RevisionDraftContext";
 
 export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> extends AzureWizardPromptStep<T> {
     public async prompt(context: T): Promise<void> {
-        if (!await settingUtils.getGlobalSetting(showDraftCommandDeployPopupKey)) {
+        if (!await settingUtils.getGlobalSetting(showDraftCommandDeployPopupSetting)) {
             context.shouldDeployRevisionDraft = false;
             return;
         }
@@ -37,7 +37,7 @@ export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> exten
         } else {
             context.shouldDeployRevisionDraft = false;
             if (result === dontAskAgain) {
-                await settingUtils.updateGlobalSetting(showDraftCommandDeployPopupKey, false);
+                await settingUtils.updateGlobalSetting(showDraftCommandDeployPopupSetting, false);
             }
         }
     }

--- a/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, type IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
+import { showDraftCommandDeployPopupKey } from "../../constants";
+import { localize } from "../../utils/localize";
+import { settingUtils } from "../../utils/settingUtils";
+import { type RevisionDraftContext } from "./RevisionDraftContext";
+
+export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> extends AzureWizardPromptStep<T> {
+    public async prompt(context: T): Promise<void> {
+        if (!await settingUtils.getGlobalSetting(showDraftCommandDeployPopupKey)) {
+            context.shouldDeployRevisionDraft = false;
+            return;
+        }
+
+        const yes: string = localize('yes', 'Yes');
+        const no: string = localize('no', 'No');
+        const dontAskAgain: string = localize('dontAskAgain', 'No, don\'t ask again');
+
+        const picks: IAzureQuickPickItem<string>[] = [
+            { label: yes, data: yes },
+            { label: no, data: no },
+            { label: dontAskAgain, data: dontAskAgain },
+        ];
+
+        const message: string = localize('deployImmediately', 'Deploy changes immediately?');
+        const result: string = (await context.ui.showQuickPick(picks, {
+            placeHolder: message,
+            suppressPersistence: true,
+        })).data;
+
+        if (result === yes) {
+            context.shouldDeployRevisionDraft = true;
+        } else {
+            context.shouldDeployRevisionDraft = false;
+            if (result === dontAskAgain) {
+                await settingUtils.updateGlobalSetting(showDraftCommandDeployPopupKey, false);
+            }
+        }
+    }
+
+    public shouldPrompt(): boolean {
+        return true;
+    }
+}

--- a/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
@@ -41,7 +41,7 @@ export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> exten
         }
     }
 
-    public shouldPrompt(context: RevisionDraftContext): boolean {
+    public shouldPrompt(context: T): boolean {
         return context.shouldDeployRevisionDraft === undefined;
     }
 }

--- a/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
@@ -19,16 +19,14 @@ export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> exten
         const yes: string = localize('yes', 'Yes');
         const no: string = localize('no', 'No');
         const dontAskAgain: string = localize('dontAskAgain', 'No, don\'t ask again');
-
         const picks: IAzureQuickPickItem<string>[] = [
             { label: yes, data: yes },
             { label: no, data: no },
             { label: dontAskAgain, data: dontAskAgain },
         ];
 
-        const message: string = localize('deployImmediately', 'Deploy changes immediately?');
         const result: string = (await context.ui.showQuickPick(picks, {
-            placeHolder: message,
+            placeHolder: localize('deployImmediately', 'Deploy changes immediately?'),
             suppressPersistence: true,
         })).data;
 

--- a/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
+++ b/src/commands/revisionDraft/RevisionDraftDeployPromptStep.ts
@@ -10,12 +10,13 @@ import { settingUtils } from "../../utils/settingUtils";
 import { type RevisionDraftContext } from "./RevisionDraftContext";
 
 export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> extends AzureWizardPromptStep<T> {
-    public async prompt(context: T): Promise<void> {
-        if (!await settingUtils.getGlobalSetting(showDraftCommandDeployPopupSetting)) {
+    public configureBeforePrompt(context: T): void | Promise<void> {
+        if (!settingUtils.getGlobalSetting(showDraftCommandDeployPopupSetting)) {
             context.shouldDeployRevisionDraft = false;
-            return;
         }
+    }
 
+    public async prompt(context: T): Promise<void> {
         const yes: string = localize('yes', 'Yes');
         const no: string = localize('no', 'No');
         const dontAskAgain: string = localize('dontAskAgain', 'No, don\'t ask again');
@@ -40,7 +41,7 @@ export class RevisionDraftDeployPromptStep<T extends RevisionDraftContext> exten
         }
     }
 
-    public shouldPrompt(): boolean {
-        return true;
+    public shouldPrompt(context: RevisionDraftContext): boolean {
+        return context.shouldDeployRevisionDraft === undefined;
     }
 }

--- a/src/commands/scaling/scaleRange/ScaleRangeContext.ts
+++ b/src/commands/scaling/scaleRange/ScaleRangeContext.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
-import { type IContainerAppContext } from "../../IContainerAppContext";
+import { type RevisionDraftContext } from "../../revisionDraft/RevisionDraftContext";
 
-export interface ScaleRangeContext extends IContainerAppContext, ExecuteActivityContext {
+export interface ScaleRangeContext extends RevisionDraftContext, ExecuteActivityContext {
     newMinRange?: number;
     newMaxRange?: number;
 

--- a/src/commands/scaling/scaleRange/editScaleRange.ts
+++ b/src/commands/scaling/scaleRange/editScaleRange.ts
@@ -11,6 +11,7 @@ import { createActivityContext } from "../../../utils/activityUtils";
 import { localize } from "../../../utils/localize";
 import { pickScale } from "../../../utils/pickItem/pickScale";
 import { getParentResource, isTemplateItemEditable, throwTemplateItemNotEditable } from "../../../utils/revisionDraftUtils";
+import { RevisionDraftDeployPromptStep } from "../../revisionDraft/RevisionDraftDeployPromptStep";
 import { type ScaleRangeContext } from "./ScaleRangeContext";
 import { ScaleRangePromptStep } from "./ScaleRangePromptStep";
 import { ScaleRangeUpdateStep } from "./ScaleRangeUpdateStep";
@@ -38,8 +39,13 @@ export async function editScaleRange(context: IActionContext, node?: ScaleItem):
 
     const wizard: AzureWizard<ScaleRangeContext> = new AzureWizard(wizardContext, {
         title: localize('editScaleRangePre', 'Update replica scaling range for "{0}" (draft)', parentResource.name),
-        promptSteps: [new ScaleRangePromptStep()],
-        executeSteps: [new ScaleRangeUpdateStep(item)],
+        promptSteps: [
+            new ScaleRangePromptStep(),
+            new RevisionDraftDeployPromptStep(),
+        ],
+        executeSteps: [
+            new ScaleRangeUpdateStep(item),
+        ],
         showLoadingPrompt: true
     });
 

--- a/src/commands/scaling/scaleRule/ScaleRuleContext.ts
+++ b/src/commands/scaling/scaleRule/ScaleRuleContext.ts
@@ -5,8 +5,8 @@
 
 import { type ScaleRule } from "@azure/arm-appcontainers";
 import { type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
-import { type IContainerAppContext } from "../../IContainerAppContext";
+import { type RevisionDraftContext } from "../../revisionDraft/RevisionDraftContext";
 
-export interface ScaleRuleContext extends IContainerAppContext, ExecuteActivityContext {
+export interface ScaleRuleContext extends RevisionDraftContext, ExecuteActivityContext {
     scaleRule?: ScaleRule;
 }

--- a/src/commands/scaling/scaleRule/addScaleRule/addScaleRule.ts
+++ b/src/commands/scaling/scaleRule/addScaleRule/addScaleRule.ts
@@ -11,6 +11,7 @@ import { createActivityContext } from "../../../../utils/activityUtils";
 import { localize } from "../../../../utils/localize";
 import { pickScaleRuleGroup } from "../../../../utils/pickItem/pickScale";
 import { getParentResource } from "../../../../utils/revisionDraftUtils";
+import { RevisionDraftDeployPromptStep } from "../../../revisionDraft/RevisionDraftDeployPromptStep";
 import { AddScaleRuleStep } from "./AddScaleRuleStep";
 import { type IAddScaleRuleContext } from "./IAddScaleRuleContext";
 import { ScaleRuleNameStep } from "./ScaleRuleNameStep";
@@ -33,8 +34,14 @@ export async function addScaleRule(context: IActionContext, node?: ScaleRuleGrou
 
     const wizard: AzureWizard<IAddScaleRuleContext> = new AzureWizard(wizardContext, {
         title: localize('addScaleRuleTitle', 'Add scale rule to "{0}" (draft)', parentResource.name),
-        promptSteps: [new ScaleRuleNameStep(), new ScaleRuleTypeListStep()],
-        executeSteps: [new AddScaleRuleStep(item)],
+        promptSteps: [
+            new ScaleRuleNameStep(),
+            new ScaleRuleTypeListStep(),
+            new RevisionDraftDeployPromptStep(),
+        ],
+        executeSteps: [
+            new AddScaleRuleStep(item),
+        ],
         showLoadingPrompt: true
     });
 

--- a/src/commands/scaling/scaleRule/deleteScaleRule/deleteScaleRule.ts
+++ b/src/commands/scaling/scaleRule/deleteScaleRule/deleteScaleRule.ts
@@ -4,13 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { type Revision } from "@azure/arm-appcontainers";
-import { AzureWizard, DeleteConfirmationStep, createSubscriptionContext, type AzureWizardExecuteStep, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { AzureWizard, DeleteConfirmationStep, createSubscriptionContext, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { type ContainerAppModel } from "../../../../tree/ContainerAppItem";
 import { type ScaleRuleItem } from "../../../../tree/scaling/ScaleRuleItem";
 import { createActivityContext } from "../../../../utils/activityUtils";
 import { localize } from "../../../../utils/localize";
 import { pickScaleRule } from "../../../../utils/pickItem/pickScale";
 import { getParentResource } from "../../../../utils/revisionDraftUtils";
+import { RevisionDraftDeployPromptStep } from "../../../revisionDraft/RevisionDraftDeployPromptStep";
 import { type ScaleRuleContext } from "../ScaleRuleContext";
 import { DeleteScaleRuleStep } from "./DeleteScaleRuleStep";
 
@@ -30,17 +31,15 @@ export async function deleteScaleRule(context: IActionContext, node?: ScaleRuleI
     }
 
     const confirmMessage = localize('confirmMessage', 'Are you sure you want to delete this scale rule?');
-
-    const promptSteps: AzureWizardPromptStep<ScaleRuleContext>[] = [
-        new DeleteConfirmationStep(confirmMessage)
-    ];
-
-    const executeSteps: AzureWizardExecuteStep<ScaleRuleContext>[] = [new DeleteScaleRuleStep(item)]
-
     const wizard: AzureWizard<ScaleRuleContext> = new AzureWizard(wizardContext, {
         title: localize('deleteScaleRuleTitle', 'Delete scale rule from "{0}" (draft)', parentResource.name),
-        promptSteps,
-        executeSteps
+        promptSteps: [
+            new DeleteConfirmationStep(confirmMessage),
+            new RevisionDraftDeployPromptStep(),
+        ],
+        executeSteps: [
+            new DeleteScaleRuleStep(item),
+        ],
     });
 
     await wizard.prompt();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,8 @@ export namespace RevisionConstants {
 }
 
 export const currentlyDeployed: string = localize('currentlyDeployed', '(currently deployed)');
-export const showDraftCommandDeployPopupKey: string = 'showDraftCommandDeployPopup';
+
+export const showDraftCommandDeployPopupSetting: string = 'showDraftCommandDeployPopup';
 
 export enum ScaleRuleTypes {
     HTTP = "HTTP scaling",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export namespace RevisionConstants {
 }
 
 export const currentlyDeployed: string = localize('currentlyDeployed', '(currently deployed)');
+export const showDraftCommandDeployPopupKey: string = 'showDraftCommandDeployPopup';
 
 export enum ScaleRuleTypes {
     HTTP = "HTTP scaling",

--- a/src/utils/pickItem/pickContainerApp.ts
+++ b/src/utils/pickItem/pickContainerApp.ts
@@ -4,13 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { parseAzureResourceId } from "@microsoft/vscode-azext-azureutils";
-import  { type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext, type QuickPickWizardContext} from "@microsoft/vscode-azext-utils";
-import { ContextValueQuickPickStep, nonNullProp, runQuickPickWizard } from "@microsoft/vscode-azext-utils";
+import { ContextValueQuickPickStep, nonNullProp, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext, type ISubscriptionActionContext, type QuickPickWizardContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import  { type ContainerAppModel } from "../../tree/ContainerAppItem";
-import { ContainerAppItem } from "../../tree/ContainerAppItem";
+import { ContainerAppItem, type ContainerAppModel } from "../../tree/ContainerAppItem";
 import { localize } from "../localize";
-import  { type PickItemOptions } from "./PickItemOptions";
+import { type PickItemOptions } from "./PickItemOptions";
 import { getPickEnvironmentSteps } from "./pickEnvironment";
 
 export function getPickContainerAppStep(containerAppName?: string | RegExp): AzureWizardPromptStep<AzureResourceQuickPickWizardContext> {
@@ -50,7 +48,7 @@ export async function pickContainerApp(context: IActionContext, options?: PickIt
 }
 
 export async function pickContainerAppWithoutPrompt(
-    context: IActionContext,
+    context: Partial<ISubscriptionActionContext> & IActionContext,
     containerApp: ContainerAppModel,
     options?: PickItemOptions
 ): Promise<ContainerAppItem> {
@@ -58,7 +56,7 @@ export async function pickContainerAppWithoutPrompt(
 
     return await runQuickPickWizard(context, {
         promptSteps: [
-            ...getPickEnvironmentSteps(true /** skipIfOne */, environmentName),
+            ...getPickEnvironmentSteps(true, context.subscriptionId, environmentName),
             getPickContainerAppStep(containerApp.name)
         ],
         title: options?.title,

--- a/src/utils/pickItem/pickEnvironment.ts
+++ b/src/utils/pickItem/pickEnvironment.ts
@@ -10,7 +10,7 @@ import { ManagedEnvironmentItem } from "../../tree/ManagedEnvironmentItem";
 import { localize } from "../localize";
 import { type PickItemOptions } from "./PickItemOptions";
 
-export function getPickEnvironmentSteps(skipIfOne: boolean = false, environmentName?: string | RegExp): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+export function getPickEnvironmentSteps(skipIfOne: boolean = false, subscriptionId?: string, environmentName?: string | RegExp): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
     const tdp: ResourceGroupsTreeDataProvider = ext.rgApiV2.resources.azureResourceTreeDataProvider;
     const types = [AzExtResourceType.ContainerAppsEnvironment];
 
@@ -22,7 +22,7 @@ export function getPickEnvironmentSteps(skipIfOne: boolean = false, environmentN
     }
 
     return [
-        new QuickPickAzureSubscriptionStep(tdp),
+        new QuickPickAzureSubscriptionStep(tdp, { selectBySubscriptionId: subscriptionId }),
         new QuickPickGroupStep(tdp, {
             groupType: types
         }),


### PR DESCRIPTION
Discussed this with Nathan a while back, and we agreed it would probably be better to use a quick pick instead of a pop-up window after each command.  This means the prompt to deploy becomes something we ask at the start rather than something we ask after the draft command finishes.

I'm proposing the process now would be - each draft command should push in the following quick pick step as the last prompt:
`new RevisionDraftDeployPromptStep()`

Almost no 'new' logic has actually been added here, mostly prompt logic from the old `RevisionDraftUpdateBaseStep` got moved into the new `RevisionDraftDeployPromptStep`.

Before (informational window):
![image](https://github.com/user-attachments/assets/669d7644-d903-45c0-b258-a634c14a8e57)

After (prompt quick pick):
![image](https://github.com/user-attachments/assets/384ef79b-877d-45d4-ae39-eba3700a1ae6)

To see in action, you can test with this command:
![image](https://github.com/user-attachments/assets/3a1ba371-88d0-4f94-a9ba-b6725cb2346b)

Edit: I forgot, I also snuck in a small fix for this...
Fixes #683