### PR TITLE
Ensure that the correct initial scale range is pre-populated in input fields

### DIFF
--- a/src/commands/scaling/scaleRange/editScaleRange.ts
+++ b/src/commands/scaling/scaleRange/editScaleRange.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type Revision, type Scale } from "@azure/arm-appcontainers";
+import { type Revision, type Scale, type Template } from "@azure/arm-appcontainers";
 import { AzureWizard, createSubscriptionContext, nonNullValueAndProp, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../../extensionVariables";
 import { type ContainerAppModel } from "../../../tree/ContainerAppItem";
 import { type ScaleItem } from "../../../tree/scaling/ScaleItem";
 import { createActivityContext } from "../../../utils/activityUtils";
@@ -25,8 +26,15 @@ export async function editScaleRange(context: IActionContext, node?: ScaleItem):
     }
 
     const parentResource: ContainerAppModel | Revision = getParentResource(containerApp, revision);
-    const scale: Scale = nonNullValueAndProp(parentResource.template, 'scale');
+    let template: Template | undefined;
 
+    if (ext.revisionDraftFileSystem.doesContainerAppsItemHaveRevisionDraft(item)) {
+        template = ext.revisionDraftFileSystem.parseRevisionDraft(item);
+    } else {
+        template = parentResource.template;
+    }
+
+    const scale: Scale = nonNullValueAndProp(template, 'scale');
     const wizardContext: ScaleRangeContext = {
         ...context,
         ...createSubscriptionContext(subscription),


### PR DESCRIPTION
Fixes an issue where we were suggesting outdated input values because we were not updating the scale range with the draft values when a draft was in session.