### PR TITLE
Update API type definition for `deployImage`

### DIFF
--- a/src/commands/api/vscode-azurecontainerapps.api.d.ts
+++ b/src/commands/api/vscode-azurecontainerapps.api.d.ts
@@ -5,6 +5,7 @@
 
 export interface AzureContainerAppsExtensionApi {
     apiVersion: string;
+    deployImage(options: DeployImageToAcaOptionsContract): Promise<void>;
     deployWorkspaceProject(options: DeployWorkspaceProjectOptionsContract): Promise<DeployWorkspaceProjectResults>;
 }
 


### PR DESCRIPTION
This is already being exported, but I forgot to add the matching API type definition for `deployImage`