### PR TITLE
Fix validation error message for naming environment variables

### DIFF
--- a/src/commands/environmentVariables/addEnvironmentVariable/EnvironmentVariableNameStep.ts
+++ b/src/commands/environmentVariables/addEnvironmentVariable/EnvironmentVariableNameStep.ts
@@ -34,10 +34,9 @@ export class EnvironmentVariableNameStep<T extends EnvironmentVariableAddContext
             return validationUtils.getInvalidCharLengthMessage();
         }
 
-        // This is the same regex used by the portal with similar warning verbiage
         const rule = /^[-._a-zA-z][-._a-zA-Z0-9]*$/;
         if (!rule.test(value)) {
-            return localize('invalidEnvName', 'Name contains invalid character. Regex used for validation is "{0}".', String(rule));
+            return localize('invalidEnvName', 'The name may contain letters, numbers, periods, underscores, or hyphens. The name may not start with a number.');
         }
 
         // Check for duplicates


### PR DESCRIPTION
Fix #871 

Portal doesn't show a validation error message anymore, but just fails if the name isn't suitable.  We'll keep the same rule that they were using / showing before, but update the error message to be better.