### PR TITLE
Add better output log messages when editing environment variables

### DIFF
--- a/src/commands/environmentVariables/convertEnvironmentVariable/convertEnvironmentVariable.ts
+++ b/src/commands/environmentVariables/convertEnvironmentVariable/convertEnvironmentVariable.ts
@@ -68,7 +68,7 @@ export async function convertEnvironmentVariable(context: IActionContext, node?:
     await wizard.prompt();
     wizardContext.activityTitle = localize('convertEnvironmentVariableActivityTitle', 'Convert environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
     editDraftStepOutputs.treeItemLabel = localize('convertLabel', 'Edit environment variable to use secret "{0}" (draft)', wizardContext.newSecretName);
-    editDraftStepOutputs.outputLogSuccessMessage = localize('convertSuccess', 'Successfully edited environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
-    editDraftStepOutputs.outputLogFailMessage = localize('convertFail', 'Failed to edit environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
+    editDraftStepOutputs.outputLogSuccessMessage = localize('convertSuccess', 'Successfully edited environment variable "{0}" to use secret "{1}" (draft).', wizardContext.environmentVariable.name, wizardContext.newSecretName);
+    editDraftStepOutputs.outputLogFailMessage = localize('convertFail', 'Failed to edit environment variable "{0}" to use secret "{1}" (draft).', wizardContext.environmentVariable.name, wizardContext.newSecretName);
     await wizard.execute();
 }

--- a/src/commands/environmentVariables/convertEnvironmentVariable/convertEnvironmentVariable.ts
+++ b/src/commands/environmentVariables/convertEnvironmentVariable/convertEnvironmentVariable.ts
@@ -15,7 +15,7 @@ import { RevisionDraftDeployPromptStep } from "../../revisionDraft/RevisionDraft
 import { SecretCreateStep } from "../../secret/addSecret/SecretCreateStep";
 import { SecretNameStep } from "../../secret/addSecret/SecretNameStep";
 import { EnvironmentVariableType } from "../addEnvironmentVariable/EnvironmentVariableTypeListStep";
-import { EnvironmentVariableEditDraftStep } from "../editEnvironmentVariable/EnvironmentVariableEditDraftStep";
+import { EnvironmentVariableEditDraftStep, type EnvironmentVariableEditOutputs } from "../editEnvironmentVariable/EnvironmentVariableEditDraftStep";
 import { type EnvironmentVariableConvertContext } from "./EnvironmentVariableConvertContext";
 
 /**
@@ -49,6 +49,9 @@ export async function convertEnvironmentVariable(context: IActionContext, node?:
     };
     wizardContext.telemetry.properties.revisionMode = containerApp.revisionsMode;
 
+    // Create an output reference to pass to the draft step so we can edit after prompting
+    const editDraftStepOutputs: EnvironmentVariableEditOutputs = {};
+
     const wizard: AzureWizard<EnvironmentVariableConvertContext> = new AzureWizard(wizardContext, {
         title: localize('convertEnvironmentVariableTitle', 'Convert environment variable "{0}" to use a secret (draft)', wizardContext.environmentVariable.name),
         promptSteps: [
@@ -58,11 +61,14 @@ export async function convertEnvironmentVariable(context: IActionContext, node?:
         executeSteps: [
             getVerifyProvidersStep<EnvironmentVariableConvertContext>(),
             new SecretCreateStep(),
-            new EnvironmentVariableEditDraftStep(item),
+            new EnvironmentVariableEditDraftStep(item, editDraftStepOutputs),
         ],
     });
 
     await wizard.prompt();
     wizardContext.activityTitle = localize('convertEnvironmentVariableActivityTitle', 'Convert environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
+    editDraftStepOutputs.treeItemLabel = localize('convertLabel', 'Edit environment variable to use secret "{0}" (draft)', wizardContext.newSecretName);
+    editDraftStepOutputs.outputLogSuccessMessage = localize('convertSuccess', 'Successfully edited environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
+    editDraftStepOutputs.outputLogFailMessage = localize('convertFail', 'Failed to edit environment variable "{0}" to use secret "{1}" (draft)', wizardContext.environmentVariable.name, wizardContext.newSecretName);
     await wizard.execute();
 }

--- a/src/commands/environmentVariables/editEnvironmentVariable/EnvironmentVariableEditDraftStep.ts
+++ b/src/commands/environmentVariables/editEnvironmentVariable/EnvironmentVariableEditDraftStep.ts
@@ -13,12 +13,18 @@ import { RevisionDraftUpdateBaseStep } from "../../revisionDraft/RevisionDraftUp
 import { EnvironmentVariableType } from "../addEnvironmentVariable/EnvironmentVariableTypeListStep";
 import { type EnvironmentVariableEditContext } from "./EnvironmentVariableEditContext";
 
+export type EnvironmentVariableEditOutputs = {
+    treeItemLabel?: string;
+    outputLogSuccessMessage?: string;
+    outputLogFailMessage?: string;
+};
+
 const environmentVariableEditDraftStepContext: string = 'environmentVariableEditDraftStepItem';
 
 export class EnvironmentVariableEditDraftStep<T extends EnvironmentVariableEditContext> extends RevisionDraftUpdateBaseStep<T> {
     public priority: number = 960;
 
-    constructor(baseItem: ContainerAppItem | RevisionsItemModel) {
+    constructor(baseItem: ContainerAppItem | RevisionsItemModel, readonly outputs: EnvironmentVariableEditOutputs = {}) {
         super(baseItem);
     }
 
@@ -55,19 +61,19 @@ export class EnvironmentVariableEditDraftStep<T extends EnvironmentVariableEditC
     public createSuccessOutput(): ExecuteActivityOutput {
         return {
             item: new ActivityChildItem({
-                label: localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
+                label: this.outputs.treeItemLabel ?? localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
                 contextValue: createContextValue([environmentVariableEditDraftStepContext, activitySuccessContext]),
                 activityType: ActivityChildType.Success,
                 iconPath: activitySuccessIcon
             }),
-            message: localize('editEnvironmentVariableSuccess', 'Edited environment variable (draft)')
+            message: this.outputs.outputLogSuccessMessage ?? localize('editEnvironmentVariableSuccess', 'Edited environment variable (draft)')
         };
     }
 
     public createProgressOutput(): ExecuteActivityOutput {
         return {
             item: new ActivityChildItem({
-                label: localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
+                label: this.outputs.treeItemLabel ?? localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
                 contextValue: createContextValue([environmentVariableEditDraftStepContext, activityProgressContext]),
                 activityType: ActivityChildType.Progress,
                 iconPath: activityProgressIcon
@@ -78,14 +84,14 @@ export class EnvironmentVariableEditDraftStep<T extends EnvironmentVariableEditC
     public createFailOutput(): ExecuteActivityOutput {
         return {
             item: new ActivityChildItem({
-                label: localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
+                label: this.outputs.treeItemLabel ?? localize('editEnvironmentVariable', 'Edit environment variable (draft)'),
                 contextValue: createContextValue([environmentVariableEditDraftStepContext, activityFailContext]),
                 initialCollapsibleState: TreeItemCollapsibleState.Expanded,
                 activityType: ActivityChildType.Fail,
                 iconPath: activityFailIcon,
                 isParent: true,
             }),
-            message: localize('editEnvironmentVariableFail', 'Failed to edit environment variable (draft).')
+            message: this.outputs.outputLogFailMessage ?? localize('editEnvironmentVariableFail', 'Failed to edit environment variable (draft).')
         };
     }
 }

--- a/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableName.ts
+++ b/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableName.ts
@@ -60,7 +60,7 @@ export async function editEnvironmentVariableName(context: IActionContext, node?
     await wizard.prompt();
     wizardContext.activityTitle = localize('editNameActivityTitle', 'Edit environment variable name to "{0}" in "{1}" (draft)', wizardContext.newEnvironmentVariableName, parentResource.name);
     editDraftStepOutputs.treeItemLabel = localize('editNameLabel', 'Edit environment variable name to "{0}" (draft)', wizardContext.newEnvironmentVariableName);
-    editDraftStepOutputs.outputLogSuccessMessage = localize('editNameSuccess', 'Successfully edited environment variable name to "{0}" in "{1}" (draft)', wizardContext.newEnvironmentVariableName, parentResource.name);
-    editDraftStepOutputs.outputLogFailMessage = localize('editNameFail', 'Failed to edit environment variable name to "{0}" in "{1}" (draft)', wizardContext.newEnvironmentVariableName, parentResource.name);
+    editDraftStepOutputs.outputLogSuccessMessage = localize('editNameSuccess', 'Successfully edited environment variable name to "{0}" in "{1}" (draft).', wizardContext.newEnvironmentVariableName, parentResource.name);
+    editDraftStepOutputs.outputLogFailMessage = localize('editNameFail', 'Failed to edit environment variable name to "{0}" in "{1}" (draft).', wizardContext.newEnvironmentVariableName, parentResource.name);
     await wizard.execute();
 }

--- a/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableValue.ts
+++ b/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableValue.ts
@@ -57,7 +57,7 @@ export async function editEnvironmentVariableValue(context: IActionContext, node
 
     await wizard.prompt();
     editDraftStepOutputs.treeItemLabel = title;
-    editDraftStepOutputs.outputLogSuccessMessage = localize('editValueSuccess', 'Successfully edited environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name);
-    editDraftStepOutputs.outputLogSuccessMessage = localize('editValueFail', 'Failed to edit environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name);
+    editDraftStepOutputs.outputLogSuccessMessage = localize('editValueSuccess', 'Successfully edited environment variable value for "{0}" (draft).', wizardContext.environmentVariable.name);
+    editDraftStepOutputs.outputLogFailMessage = localize('editValueFail', 'Failed to edit environment variable value for "{0}" (draft).', wizardContext.environmentVariable.name);
     await wizard.execute();
 }

--- a/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableValue.ts
+++ b/src/commands/environmentVariables/editEnvironmentVariable/editEnvironmentVariableValue.ts
@@ -14,7 +14,7 @@ import { isTemplateItemEditable, TemplateItemNotEditableError } from "../../../u
 import { RevisionDraftDeployPromptStep } from "../../revisionDraft/RevisionDraftDeployPromptStep";
 import { EnvironmentVariableTypeListStep } from "../addEnvironmentVariable/EnvironmentVariableTypeListStep";
 import { type EnvironmentVariableEditContext } from "./EnvironmentVariableEditContext";
-import { EnvironmentVariableEditDraftStep } from "./EnvironmentVariableEditDraftStep";
+import { EnvironmentVariableEditDraftStep, type EnvironmentVariableEditOutputs } from "./EnvironmentVariableEditDraftStep";
 
 export async function editEnvironmentVariableValue(context: IActionContext, node?: EnvironmentVariableItem): Promise<void> {
     const item: EnvironmentVariableItem = node ?? await pickEnvironmentVariable(context, { autoSelectDraft: true });
@@ -39,18 +39,25 @@ export async function editEnvironmentVariableValue(context: IActionContext, node
     };
     wizardContext.telemetry.properties.revisionMode = containerApp.revisionsMode;
 
+    // Create an output reference to pass to the draft step so we can edit after prompting
+    const editDraftStepOutputs: EnvironmentVariableEditOutputs = {};
+
+    const title: string = localize('editEnvironmentVariableValue', 'Edit environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name);
     const wizard: AzureWizard<EnvironmentVariableEditContext> = new AzureWizard(wizardContext, {
-        title: localize('editEnvironmentVariableValue', 'Edit environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name),
+        title,
         promptSteps: [
             new EnvironmentVariableTypeListStep(),
             new RevisionDraftDeployPromptStep(),
         ],
         executeSteps: [
             getVerifyProvidersStep<EnvironmentVariableEditContext>(),
-            new EnvironmentVariableEditDraftStep(item),
+            new EnvironmentVariableEditDraftStep(item, editDraftStepOutputs),
         ],
     });
 
     await wizard.prompt();
+    editDraftStepOutputs.treeItemLabel = title;
+    editDraftStepOutputs.outputLogSuccessMessage = localize('editValueSuccess', 'Successfully edited environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name);
+    editDraftStepOutputs.outputLogSuccessMessage = localize('editValueFail', 'Failed to edit environment variable value for "{0}" (draft)', wizardContext.environmentVariable.name);
     await wizard.execute();
 }


### PR DESCRIPTION
Fixes #874 

The output strings shown in the issue are [too] generic because I have all environment variable edit commands leveraging the same generic execute step.  The simplest solution I could think of was to just allow passing of the customized strings during instantiation.