### PR TITLE
Add functionality to copilot button

### DIFF
--- a/src/commands/deployContainerApp/deployContainerApp.ts
+++ b/src/commands/deployContainerApp/deployContainerApp.ts
@@ -59,14 +59,15 @@ export async function deployContainerApp(context: IActionContext, node?: Contain
 
     const confirmationViewTitle: string = localize('confirmAndDeploy', 'Confirm + Deploy')
     const confirmationViewDescription: string = localize('viewDescription', 'Please select an input you would like to change. Otherwise click "Confirm" to deploy.');
+    const title: string = localize('deployContainerAppTitle', 'Deploy image to container app')
 
     const wizard: AzureWizard<ContainerAppDeployContext> = new AzureWizard(wizardContext, {
-        title: localize('deployContainerAppTitle', 'Deploy image to container app'),
+        title: title,
         promptSteps: [
             new ContainerAppDeployStartingResourcesLogStep(),
             new ImageSourceListStep(),
             new ContainerAppOverwriteConfirmStep(),
-            new OpenConfirmationViewStep(confirmationViewTitle, confirmationViewDescription, () => wizard.confirmationViewProperties)
+            new OpenConfirmationViewStep(confirmationViewTitle, confirmationViewDescription, title, () => wizard.confirmationViewProperties)
         ],
         executeSteps: [
             getVerifyProvidersStep<ContainerAppDeployContext>(),

--- a/src/webviews/ConfirmationView.tsx
+++ b/src/webviews/ConfirmationView.tsx
@@ -36,6 +36,7 @@ export const ConfirmationView = (): JSX.Element => {
     const configuration = useConfiguration<ConfirmationViewControllerType>();
     const title = configuration.title;
     const description = configuration.description;
+    const commandName = configuration.commandName;
     const confirmClicked = () => {
         const selectedItemIndex = Number(Array.from(selectedItems)[0]);
         const itemsToClear = configuration.items.length - selectedItemIndex;
@@ -49,9 +50,9 @@ export const ConfirmationView = (): JSX.Element => {
     const copilotClicked = (name: string, value: string) => {
         vscodeApi.postMessage({
             command: ConfirmationViewCommands.Copilot,
-            itemsToClear: 0,
             name: name,
-            value: value
+            value: value,
+            commandName: commandName
         });
     }
 

--- a/src/webviews/ConfirmationViewController.ts
+++ b/src/webviews/ConfirmationViewController.ts
@@ -11,6 +11,7 @@ import { WebviewController } from "./extension-server/WebviewController";
 export type ConfirmationViewControllerType = {
     title: string;
     description: string;
+    commandName: string;
     items: Array<ConfirmationViewProperty>
 }
 

--- a/src/webviews/ConfirmationViewController.ts
+++ b/src/webviews/ConfirmationViewController.ts
@@ -11,7 +11,7 @@ import { WebviewController } from "./extension-server/WebviewController";
 export type ConfirmationViewControllerType = {
     title: string;
     description: string;
-    commandName: string;
+    commandName: string; // only used to help construct the copilot prompt
     items: Array<ConfirmationViewProperty>
 }
 

--- a/src/webviews/OpenConfirmationViewStep.ts
+++ b/src/webviews/OpenConfirmationViewStep.ts
@@ -16,18 +16,21 @@ export class OpenConfirmationViewStep<T extends IActionContext> extends AzureWiz
     private readonly viewConfig: () => ConfirmationViewProperty[];
     private readonly title: string;
     private readonly description: string;
+    private readonly commandName: string;
 
-    public constructor(title: string, description: string, viewConfig: () => ConfirmationViewProperty[]) {
+    public constructor(title: string, description: string, commandName: string, viewConfig: () => ConfirmationViewProperty[]) {
         super();
         this.title = title;
         this.description = description;
         this.viewConfig = viewConfig;
+        this.commandName = commandName;
     }
 
     public async prompt(_context: T): Promise<void> {
         const confirmationView = new ConfirmationViewController({
             title: this.title,
             description: this.description,
+            commandName: this.commandName,
             items: this.viewConfig()
         });
 

--- a/src/webviews/extension-server/WebviewController.ts
+++ b/src/webviews/extension-server/WebviewController.ts
@@ -53,7 +53,7 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
         this._panel.iconPath = this._iconPath;
 
         this._panel.webview.onDidReceiveMessage(
-            async (message: { command: string, itemsToClear?: number, name?: string, value?: string }) => {
+            async (message: { command: string, itemsToClear?: number, name?: string, value?: string, commandName?: string }) => {
                 // Todo: these are placeholders. May change to using trpc for the webview
                 switch (message.command) {
                     case 'cancel':
@@ -68,7 +68,7 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
                         await vscode.commands.executeCommand("workbench.action.chat.newChat");
                         await vscode.commands.executeCommand("workbench.action.chat.open", {
                             mode: 'agent',
-                            query: createCopilotPromptForConfirmationViewButton(nonNullValue(message.name), nonNullValue(message.value), 'deploy container app to Azure', 'Azure Container Apps'),
+                            query: createCopilotPromptForConfirmationViewButton(nonNullValue(message.name), nonNullValue(message.value), nonNullValue(message.commandName), 'Azure Container Apps'),
                         });
 
                         break;
@@ -111,5 +111,5 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
 }
 
 export function createCopilotPromptForConfirmationViewButton(name: string, value: string, command: string, extension: string): string {
-    return `Help explain what ${name}: ${value} means in the context of the ${command} command using the ${extension} extension for VSCode.`
+    return `Help explain what ${name}: ${value} means in the context of the "${command}" command using the ${extension} extension for VSCode.`
 }

--- a/src/webviews/extension-server/WebviewController.ts
+++ b/src/webviews/extension-server/WebviewController.ts
@@ -111,6 +111,6 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
     }
 }
 
-export function createCopilotPromptForConfirmationViewButton(name: string, value: string, command: string, extension: string): string {
-    return `Help explain what ${name}: ${value} means in the context of the "${command}" command using the ${extension} extension for VSCode.`
+export function createCopilotPromptForConfirmationViewButton(name: string, value: string, commandName: string, extension: string): string {
+    return `Help explain what ${name}: ${value} means in the context of the "${commandName}" command using the ${extension} extension for VSCode.`
 }

--- a/src/webviews/extension-server/WebviewController.ts
+++ b/src/webviews/extension-server/WebviewController.ts
@@ -65,6 +65,7 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
                         this._panel.dispose();
                         break;
                     case 'copilot':
+                        await vscode.commands.executeCommand("workbench.action.chat.open");
                         await vscode.commands.executeCommand("workbench.action.chat.newChat");
                         await vscode.commands.executeCommand("workbench.action.chat.open", {
                             mode: 'agent',

--- a/src/webviews/extension-server/WebviewController.ts
+++ b/src/webviews/extension-server/WebviewController.ts
@@ -2,6 +2,7 @@
 *  Copyright (c) Microsoft Corporation. All rights reserved.
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
+import { nonNullValue } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { SharedState } from '../OpenConfirmationViewStep';
 import { WebviewBaseController } from './WebviewBaseController';
@@ -52,7 +53,7 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
         this._panel.iconPath = this._iconPath;
 
         this._panel.webview.onDidReceiveMessage(
-            async (message: { command: string, itemsToClear?: number }) => {
+            async (message: { command: string, itemsToClear?: number, name?: string, value?: string }) => {
                 // Todo: these are placeholders. May change to using trpc for the webview
                 switch (message.command) {
                     case 'cancel':
@@ -62,6 +63,14 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
                     case 'confirm':
                         SharedState.itemsToClear = message.itemsToClear ?? 0;
                         this._panel.dispose();
+                        break;
+                    case 'copilot':
+                        await vscode.commands.executeCommand("workbench.action.chat.newChat");
+                        await vscode.commands.executeCommand("workbench.action.chat.open", {
+                            mode: 'agent',
+                            query: createCopilotPromptForConfirmationViewButton(nonNullValue(message.name), nonNullValue(message.value), 'deploy container app to Azure', 'Azure Container Apps'),
+                        });
+
                         break;
                 }
             }
@@ -99,4 +108,8 @@ export class WebviewController<Configuration> extends WebviewBaseController<Conf
     public revealToForeground(viewColumn: vscode.ViewColumn = vscode.ViewColumn.One): void {
         this._panel.reveal(viewColumn, true);
     }
+}
+
+export function createCopilotPromptForConfirmationViewButton(name: string, value: string, command: string, extension: string): string {
+    return `Help explain what ${name}: ${value} means in the context of the ${command} command using the ${extension} extension for VSCode.`
 }


### PR DESCRIPTION
This opens the chat and adds a prompt when the copilot button is pressed within the confirmation view. Here is an example of what the prompt looks like and the copilot response: 
![image](https://github.com/user-attachments/assets/b1267ffa-c03f-4373-a254-7444b6776de5)
