### PR TITLE
Fix extra nodes appearing when going back

### DIFF
--- a/src/commands/image/imageSource/EnvFileListStep.ts
+++ b/src/commands/image/imageSource/EnvFileListStep.ts
@@ -81,6 +81,13 @@ export class EnvFileListStep<T extends EnvFileListContext> extends AzureWizardPr
         };
     }
 
+    public undo(context: T): void {
+        // Pop the activity children if the user goes back
+        if (context.activityChildren) {
+            context.activityChildren.pop();
+        }
+    }
+
     private async promptForEnvPath(context: T, showHasExistingData?: boolean): Promise<string | undefined> {
         const placeHolder: string = localize('setEnvVar', 'Select a {0} file to set the environment variables for the container instance', '.env');
         const skipLabel: string | undefined = showHasExistingData ? localize('useExisting', 'Use existing configuration') : undefined;


### PR DESCRIPTION
This seems to only really be happening with the `EnvFileListStep` because the activity log node is being pushed on manually. To fix this just added an undo function that pops off the step from the activity log when a `GoBackError` is thrown. For the confirmation view this seems to only be happening with this step but @MicroFish91 if you have used this logic in other places this issue will still happen if a users presses go back (in confirmation view or from the quick pick). 