### PR TITLE
Fix env file path going onto next column

### DIFF
--- a/src/webviews/ConfirmationView.tsx
+++ b/src/webviews/ConfirmationView.tsx
@@ -73,8 +73,8 @@ export const ConfirmationView = (): JSX.Element => {
             minWidth: 200,
         },
         value: {
-            defaultWidth: 200,
-            minWidth: 200,
+            defaultWidth: 275,
+            minWidth: 275,
         }
     }
 


### PR DESCRIPTION
This makes the view a bit wider to accomodate for longer env file paths: 
<img width="985" height="629" alt="image" src="https://github.com/user-attachments/assets/72a2fc75-90e3-4399-9a2d-489705b42752" />
It doesn't completly get rid of the problem but should allow for much longer file paths than before.