### PR TITLE
Change copilot icon on confirmation view from sparkle to the ghost icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "@microsoft/vscode-azext-github": "^1.0.2",
                 "@microsoft/vscode-azext-utils": "^3.3.0",
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
+                "@vscode/codicons": "0.0.38",
                 "buffer": "^6.0.3",
                 "dayjs": "^1.11.3",
                 "deep-eql": "^4.1.3",
@@ -3838,6 +3839,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@vscode/codicons": {
+            "version": "0.0.38",
+            "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.38.tgz",
+            "integrity": "sha512-g4uInb63ECu0URD0DlyBzwXu2TksWUOaMSzQcKRoc3mXSNrjR3wC7EB3PA0Iq83eK8KCEKoVzkC1clt/r1euqA==",
+            "license": "CC-BY-4.0"
         },
         "node_modules/@vscode/extension-telemetry": {
             "version": "0.9.6",

--- a/package.json
+++ b/package.json
@@ -866,6 +866,7 @@
         "@microsoft/vscode-azext-github": "^1.0.2",
         "@microsoft/vscode-azext-utils": "^3.3.0",
         "@microsoft/vscode-azureresources-api": "^2.0.2",
+        "@vscode/codicons": "0.0.38",
         "buffer": "^6.0.3",
         "dayjs": "^1.11.3",
         "deep-eql": "^4.1.3",

--- a/src/webviews/ConfirmationView.tsx
+++ b/src/webviews/ConfirmationView.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button, createTableColumn, DataGrid, DataGridBody, DataGridCell, DataGridRow, TableCellLayout, Tooltip, type OnSelectionChangeData, type SelectionItemId, type TableColumnDefinition } from '@fluentui/react-components';
-import { Sparkle16Filled } from '@fluentui/react-icons';
 import * as React from 'react';
 import { useContext, useState, type JSX } from 'react';
 import './confirmationView.scss';
@@ -97,7 +96,7 @@ export const ConfirmationView = (): JSX.Element => {
                 return <TableCellLayout className='copilot'>
                     <Tooltip content='Ask Copilot' relationship='label'>
                         <Button
-                            appearance='transparent' icon={<Sparkle16Filled />} onClick={(event) => {
+                            appearance='transparent' icon={<div className='codicon codicon-copilot'></div>} onClick={(event) => {
                                 event.stopPropagation();
                                 copilotClicked(item.name, item.value);
                             }}>

--- a/src/webviews/extension-server/WebviewBaseController.ts
+++ b/src/webviews/extension-server/WebviewBaseController.ts
@@ -75,6 +75,8 @@ export abstract class WebviewBaseController<Configuration> implements vscode.Dis
                 ]
         ).join(' ');
 
+        const codiconsUri = webview?.asWebviewUri(vscode.Uri.joinPath(ext.context.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
+
         /**
          * Note to code maintainers:
          * encodeURIComponent(JSON.stringify(this.configuration)) below is crucial
@@ -86,6 +88,7 @@ export abstract class WebviewBaseController<Configuration> implements vscode.Dis
                 <head>
                     <meta charset="UTF-8">
                     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <link href="${codiconsUri}" rel="stylesheet" />
                     <meta // noinspection JSAnnotator
                         http-equiv="Content-Security-Policy" content="${csp}" />
                 </head>
@@ -101,7 +104,6 @@ export abstract class WebviewBaseController<Configuration> implements vscode.Dis
                                 import { render } from "${srcUri}";
                                 render('${this._webviewName}', acquireVsCodeApi());
                             </script>
-
                     </body>
                 </html>`;
     }


### PR DESCRIPTION
Here is how the view now looks: 
<img width="1058" height="618" alt="image" src="https://github.com/user-attachments/assets/d3987afc-d452-4944-b7a3-d3f91d4a20f9" />
