### PR TITLE
Rethrow errors for deploy workspace project API

### DIFF
--- a/src/commands/api/deployWorkspaceProjectApi.ts
+++ b/src/commands/api/deployWorkspaceProjectApi.ts
@@ -20,6 +20,8 @@ import type * as api from "./vscode-azurecontainerapps.api";
 
 export async function deployWorkspaceProjectApi(deployWorkspaceProjectOptions: api.DeployWorkspaceProjectOptionsContract): Promise<DeployWorkspaceProjectResults> {
     return await callWithTelemetryAndErrorHandling('containerApps.api.deployWorkspaceProject', async (context: IActionContext): Promise<DeployWorkspaceProjectResults> => {
+        context.errorHandling.rethrow = true;
+
         const {
             resourceGroupId,
             location,


### PR DESCRIPTION
If the api call fails, we want to be able to see the error from the calling extension, otherwise it might appear as a false positive