### PR TITLE
Add ACA "flat" tree item provider and "reveal app" command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,16 @@
                 "branches": [
                     {
                         "type": "ContainerAppsEnvironment"
+                    },
+                    {
+                        "type": "ContainerApps"
                     }
                 ]
             },
             "activation": {
                 "onResolve": [
-                    "microsoft.app/managedenvironments"
+                    "microsoft.app/managedenvironments",
+                    "microsoft.app/containerapps"
                 ]
             },
             "commands": [
@@ -190,6 +194,11 @@
             {
                 "command": "containerApps.browse",
                 "title": "%containerApps.browse%",
+                "category": "Azure Container Apps"
+            },
+            {
+                "command": "containerApps.revealInEnvironment",
+                "title": "%containerApps.revealInEnvironment%",
                 "category": "Azure Container Apps"
             },
             {
@@ -376,6 +385,11 @@
                     "command": "containerApps.browse",
                     "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /containerAppItem/i",
                     "group": "1@1"
+                },
+                {
+                    "command": "containerApps.revealInEnvironment",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /containerAppResourceItem/i",
+                    "group": "1_navigate@1"
                 },
                 {
                     "command": "containerApps.restartRevision",

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
     "containerApps.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "containerApps.showDraftCommandDeployPopup": "Prompt to deploy revision draft whenever a draft command is run.",
     "containerApps.browse": "Browse",
+    "containerApps.revealInEnvironment": "Reveal in Container Apps Environments",
     "containerApps.createContainerApp": "Create Container App...",
     "containerApps.editContainerApp": "Edit Container App (Advanced)...",
     "containerApps.editContainer": "Edit Container...",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -35,6 +35,7 @@ import { toggleIngressVisibility } from './ingress/toggleIngressVisibility/toggl
 import { startStreamingLogs } from './logStream/startStreamingLogs';
 import { stopStreamingLogs } from './logStream/stopStreamingLogs';
 import { openConsoleInPortal } from './openConsoleInPortal';
+import { revealInEnvironment } from './revealInEnvironment';
 import { activateRevision } from './revision/activateRevision';
 import { chooseRevisionMode } from './revision/chooseRevisionMode/chooseRevisionMode';
 import { deactivateRevision } from './revision/deactivateRevision';
@@ -66,6 +67,7 @@ export function registerCommands(): void {
     registerCommandWithTreeNodeUnwrapping('containerApps.deleteContainerApp', deleteContainerApp);
     registerCommandWithTreeNodeUnwrapping('containerApps.editContainerApp', editContainerApp);
     registerCommandWithTreeNodeUnwrapping('containerApps.openConsoleInPortal', openConsoleInPortal);
+    registerCommandWithTreeNodeUnwrapping('containerApps.revealInEnvironment', revealInEnvironment);
     registerCommandWithTreeNodeUnwrapping('containerApps.toggleEnvironmentVariableVisibility',
         async (context: IActionContext, item: EnvironmentVariableItem) => {
             await item.toggleValueVisibility(context);

--- a/src/commands/revealInEnvironment.ts
+++ b/src/commands/revealInEnvironment.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getResourceGroupFromId } from '@microsoft/vscode-azext-azureutils';
+import { parseError, type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { ext } from '../extensionVariables';
+import { ContainerAppItem } from '../tree/ContainerAppItem';
+import { ContainerAppResourceItem } from '../tree/ContainerAppResourceItem';
+import { localize } from '../utils/localize';
+
+interface MaybeContainerAppRaw {
+    properties?: { managedEnvironmentId?: string };
+}
+
+/**
+ * Navigates from a {@link ContainerAppResourceItem} (under the standalone
+ * `AzExtResourceType.ContainerApps` group) to the equivalent app's parent
+ * environment under the `AzExtResourceType.ContainerAppsEnvironment` group.
+ *
+ * The host's `revealAzureResource` walks the tree using a `startsWith` ancestor
+ * check on Azure resource ids -- but a container app's ARM id is a *sibling* of
+ * its managed environment's id, not a descendant. So host-side reveal can only
+ * locate the env in the env-rooted hierarchy. We reveal the env with
+ * `expand: true` so the user immediately sees the target app under it.
+ */
+export async function revealInEnvironment(context: IActionContext, item: ContainerAppResourceItem): Promise<void> {
+    if (!item || typeof (item as ContainerAppResourceItem).containerAppId !== 'string') {
+        return;
+    }
+
+    const containerAppId = item.containerAppId;
+
+    // Prefer managedEnvironmentId from the cached raw resource (avoids a network round trip).
+    let managedEnvironmentId = (item.resource.raw as MaybeContainerAppRaw | undefined)?.properties?.managedEnvironmentId;
+    if (!managedEnvironmentId) {
+        const containerApp = await ContainerAppItem.Get(
+            context,
+            item.subscription,
+            getResourceGroupFromId(containerAppId),
+            item.resource.name);
+        managedEnvironmentId = containerApp.managedEnvironmentId;
+    }
+
+    if (!managedEnvironmentId) {
+        ext.outputChannel.appendLog(localize('revealInEnvNoEnvId', 'Unable to determine managed environment id for container app "{0}".', item.resource.name));
+        return;
+    }
+
+    // Make sure the Azure Resources view is showing -- reveal does nothing visible if it isn't.
+    try {
+        await vscode.commands.executeCommand('azureResourceGroups.focus');
+    } catch {
+        // Not fatal. Older host versions or alternate views; continue with reveal.
+    }
+
+    try {
+        await ext.rgApiV2.resources.revealAzureResource(managedEnvironmentId, {
+            select: true,
+            focus: true,
+            expand: true,
+        });
+    } catch (err) {
+        const parsed = parseError(err);
+        context.telemetry.properties.revealError = parsed.errorType;
+        ext.outputChannel.appendLog(localize('revealInEnvFailed', 'Failed to reveal managed environment "{0}": {1}', managedEnvironmentId, parsed.message));
+        throw err;
+    }
+}

--- a/src/commands/revealInEnvironment.ts
+++ b/src/commands/revealInEnvironment.ts
@@ -27,7 +27,7 @@ interface MaybeContainerAppRaw {
  * `expand: true` so the user immediately sees the target app under it.
  */
 export async function revealInEnvironment(context: IActionContext, item: ContainerAppResourceItem): Promise<void> {
-    if (!item || typeof (item as ContainerAppResourceItem).containerAppId !== 'string') {
+    if (!ContainerAppResourceItem.isContainerAppResourceItem(item)) {
         return;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { createContainerAppsApiProvider } from './commands/api/createContainerAp
 import { registerCommands } from './commands/registerCommands';
 import { RevisionDraftFileSystem } from './commands/revisionDraft/RevisionDraftFileSystem';
 import { ext } from './extensionVariables';
+import { ContainerAppsResourceBranchDataProvider } from './tree/ContainerAppResourceItem';
 import { ContainerAppsBranchDataProvider } from './tree/ContainerAppsBranchDataProvider';
 import { localize } from './utils/localize';
 
@@ -44,6 +45,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
 
         ext.state = new TreeElementStateManager();
         ext.branchDataProvider = new ContainerAppsBranchDataProvider();
+        ext.containerAppsResourceBranchDataProvider = new ContainerAppsResourceBranchDataProvider();
 
         const authHandshakeId = uuid();
         const authHandshakeStartMs = Date.now();
@@ -63,6 +65,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
 
                 ext.rgApiV2 = rgApiV2;
                 ext.rgApiV2.resources.registerAzureResourceBranchDataProvider(AzExtResourceType.ContainerAppsEnvironment, ext.branchDataProvider);
+                ext.rgApiV2.resources.registerAzureResourceBranchDataProvider(AzExtResourceType.ContainerApps, ext.containerAppsResourceBranchDataProvider);
             });
         };
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -7,6 +7,7 @@ import { type IAzExtOutputChannel, type IExperimentationServiceAdapter, type Tre
 import { type AzureResourcesExtensionApi } from "@microsoft/vscode-azureresources-api";
 import { type ExtensionContext } from "vscode";
 import { type RevisionDraftFileSystem } from "./commands/revisionDraft/RevisionDraftFileSystem";
+import { type ContainerAppsResourceBranchDataProvider } from "./tree/ContainerAppResourceItem";
 import { type ContainerAppsBranchDataProvider } from "./tree/ContainerAppsBranchDataProvider";
 
 /**
@@ -23,4 +24,5 @@ export namespace ext {
 
     export let state: TreeElementStateManager;
     export let branchDataProvider: ContainerAppsBranchDataProvider;
+    export let containerAppsResourceBranchDataProvider: ContainerAppsResourceBranchDataProvider;
 }

--- a/src/tree/ContainerAppResourceItem.ts
+++ b/src/tree/ContainerAppResourceItem.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { createContextValue } from '@microsoft/vscode-azext-utils';
+import { type AzureResource, type AzureResourceBranchDataProvider, type AzureSubscription, type ViewPropertiesModel } from '@microsoft/vscode-azureresources-api';
+import * as vscode from 'vscode';
+import { ext } from '../extensionVariables';
+import { createPortalUrl } from '../utils/createPortalUrl';
+import { treeUtils } from '../utils/treeUtils';
+import { type TreeElementBase } from './ContainerAppsBranchDataProvider';
+
+/**
+ * Flat tree item representing a Microsoft.App/containerApps resource shown under
+ * the host's standalone "Container Apps" (`AzExtResourceType.ContainerApps`) group.
+ *
+ * The full container-app hierarchy lives under the `ContainerAppsEnvironment` group.
+ * This item exists so the secondary group renders proper labels/icons and offers a
+ * shortcut to the equivalent node in the environments hierarchy, instead of the
+ * unhandled host stub that previously appeared as a bare leaf with no actions.
+ */
+export class ContainerAppResourceItem implements TreeElementBase {
+    static readonly contextValue: string = 'containerAppResourceItem';
+    static readonly contextValueRegExp: RegExp = new RegExp(ContainerAppResourceItem.contextValue);
+
+    /**
+     * Suffix appended to the underlying ARM id so this flat node has a tree id
+     * distinct from the rich {@link ContainerAppItem} that also represents the
+     * same Azure resource under the environments hierarchy. Without this, the
+     * host's `revealAzureResource(<arm id>)` call could resolve to either node.
+     */
+    static readonly idSuffix: string = '#flat';
+
+    readonly id: string;
+    readonly viewProperties: ViewPropertiesModel;
+    readonly portalUrl: vscode.Uri;
+
+    constructor(public readonly subscription: AzureSubscription, public readonly resource: AzureResource) {
+        this.id = `${resource.id}${ContainerAppResourceItem.idSuffix}`;
+        this.portalUrl = createPortalUrl(subscription, resource.id);
+        this.viewProperties = {
+            data: resource.raw,
+            label: resource.name,
+        };
+    }
+
+    /** The ARM id of the underlying container app, without the flat-node id suffix. */
+    get containerAppId(): string {
+        return this.resource.id;
+    }
+
+    private get contextValue(): string {
+        return createContextValue([ContainerAppResourceItem.contextValue, this.resource.name]);
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        return {
+            id: this.id,
+            label: this.resource.name,
+            iconPath: treeUtils.getIconPath('azure-containerapps'),
+            contextValue: this.contextValue,
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+        };
+    }
+
+    getChildren(): TreeElementBase[] {
+        return [];
+    }
+
+    static isContainerAppResourceItem(item: unknown): item is ContainerAppResourceItem {
+        return typeof item === 'object' && item !== null &&
+            typeof (item as ContainerAppResourceItem).contextValue === 'string' &&
+            ContainerAppResourceItem.contextValueRegExp.test((item as ContainerAppResourceItem).contextValue);
+    }
+}
+
+/**
+ * Branch data provider for the host's standalone `AzExtResourceType.ContainerApps`
+ * group. Returns a flat {@link ContainerAppResourceItem} per resource and exposes
+ * no children -- the primary hierarchy is rooted at the managed environment.
+ */
+export class ContainerAppsResourceBranchDataProvider extends vscode.Disposable implements AzureResourceBranchDataProvider<TreeElementBase> {
+    private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<TreeElementBase | undefined>();
+
+    constructor() {
+        super(() => this.onDidChangeTreeDataEmitter.dispose());
+    }
+
+    get onDidChangeTreeData(): vscode.Event<TreeElementBase | undefined> {
+        return this.onDidChangeTreeDataEmitter.event;
+    }
+
+    getResourceItem(element: AzureResource): TreeElementBase {
+        const item = new ContainerAppResourceItem(element.subscription, element);
+        return ext.state.wrapItemInStateHandling(item as TreeElementBase & { id: string }, () => this.refresh(item));
+    }
+
+    getChildren(element: TreeElementBase): vscode.ProviderResult<TreeElementBase[]> {
+        return element.getChildren?.() ?? [];
+    }
+
+    async getTreeItem(element: TreeElementBase): Promise<vscode.TreeItem> {
+        return await element.getTreeItem();
+    }
+
+    refresh(element?: TreeElementBase): void {
+        this.onDidChangeTreeDataEmitter.fire(element);
+    }
+}


### PR DESCRIPTION
### Problem

The Azure Resources view was showing **two** sibling top-level Container Apps nodes per subscription:

1. **Container Apps** (mapped from `AzExtResourceType.ContainerAppsEnvironment`) — the rich hierarchy this extension contributes: environments → apps → revisions/configuration/logs/etc.
2. **ContainerApps** (mapped from `AzExtResourceType.ContainerApps`) — an unhandled stub that listed every `Microsoft.App/containerApps` resource as a bare leaf with no children, default Azure resource context menu, and the un-localized enum string as its label.

This happens because the Azure Resources host renders one top-level group per `AzExtResourceType` it discovers via Resource Graph, and `Microsoft.App/containerApps` resources surface as a separate type alongside `Microsoft.App/managedEnvironments`. Without a branch data provider registered for `AzExtResourceType.ContainerApps`, the host falls back to a default flat rendering — hence the asymmetric and confusing pair of root nodes.

This is a similar pattern to other Azure extensions where multiple related resource types each get their own top-level group (e.g. SQL servers + SQL databases, Cosmos variants), but in our case the secondary group contributes little value.

### Approach

Rather than try to suppress the secondary group (the host doesn't expose an API to do so), this PR registers a minimal branch data provider for `AzExtResourceType.ContainerApps` that:

- Renders each container app with the proper ACA icon, label, portal URL, and "View Properties" support.
- Has no children — the rich hierarchy continues to live under the environments group, which remains the canonical place to manage apps.
- Adds a context menu entry, **"Reveal in Container Apps Environments"**, that navigates to the equivalent app's parent managed environment under the environments hierarchy and expands it, so users coming in via the secondary group can quickly hop to the full tree.

### Why reveal goes to the *environment*, not the app

The Azure Resources host's `revealAzureResource` walks the tree using a `startsWith(resourceId)` ancestor check. A container app's ARM id is a *sibling* of its managed environment's id, not a descendant, so revealing the app id from the standalone group can never descend into the environments hierarchy — it only ever finds the same flat node we started from. Revealing the parent environment with `expand: true` is the closest behavior the host's public API supports, and it lands the user one click away from the target app.

### Notes / known limitations

- **Group label is still "ContainerApps"** rather than something nicer like "Container Apps". The host's group display names come from a hardcoded map in `vscode-azureresourcegroups` that has an entry for `ContainerAppsEnvironment` but not for `ContainerApps`, so the host falls back to the raw enum string. A friendlier label needs an upstream change to the host extension's `azExtDisplayInfo` map. (See [vscode-azureresourcegroups#1432](https://github.com/microsoft/vscode-azureresourcegroups/issues/1432)
- The secondary group still duplicates each app as a flat leaf. We can't avoid that without host-side changes; this PR makes the duplication useful instead of broken.
- Reveal requires the Azure Resources view to be visible; the command focuses it via `azureResourceGroups.focus` before calling `revealAzureResource` to make the navigation reliable.

### Testing

Manually verified in an Extension Development Host against a subscription containing managed environments and apps:

- Both top-level groups appear; the new "ContainerApps" group shows leaves with the correct ACA icon, label, "View Properties", and "Open in Portal".
- Right-clicking a leaf in the secondary group exposes only **Reveal in Container Apps Environments**, which scrolls to and expands the app's managed environment in the environments group.
- The existing rich hierarchy under the environments group is unchanged.