### PR TITLE
Add Express Container Apps support in resource tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
                 "category": "Azure Container Apps"
             },
             {
+                "command": "containerApps.openExpressPortal",
+                "title": "%containerApps.openExpressPortal%",
+                "category": "Azure Container Apps"
+            },
+            {
                 "command": "containerApps.editContainer",
                 "title": "%containerApps.editContainer%",
                 "category": "Azure Container Apps"
@@ -450,6 +455,11 @@
                     "command": "containerApps.chooseRevisionMode",
                     "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /containerAppItem/i",
                     "group": "6@2"
+                },
+                {
+                    "command": "containerApps.openExpressPortal",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /containerAppItem(.*)express/i",
+                    "group": "9@2"
                 },
                 {
                     "command": "containerApps.openConsoleInPortal",

--- a/package.nls.json
+++ b/package.nls.json
@@ -51,6 +51,7 @@
     "containerApps.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete.",
     "containerApps.openInPortal": "Open in Portal",
     "containerApps.openConsoleInPortal": "Open Console in Portal",
+    "containerApps.openExpressPortal": "Open in Express Portal",
     "containerApps.editScaleRange": "Edit Scaling Range...",
     "containerApps.addScaleRule": "Add Scale Rule...",
     "containerApps.deleteScaleRule": "Delete Scale Rule...",

--- a/src/commands/openExpressPortal.ts
+++ b/src/commands/openExpressPortal.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { type IActionContext } from "@microsoft/vscode-azext-utils";
+import { env, Uri } from "vscode";
+import { expressPortalBaseUrl } from "../constants";
+import { type ContainerAppItem } from "../tree/ContainerAppItem";
+import { pickContainerApp } from "../utils/pickItem/pickContainerApp";
+
+export async function openExpressPortal(context: IActionContext, node?: ContainerAppItem): Promise<void> {
+    node ??= await pickContainerApp(context);
+    const url = `${expressPortalBaseUrl}/${node.subscription.subscriptionId}/${node.containerApp.resourceGroup}/${node.containerApp.name}/overview`;
+    await env.openExternal(Uri.parse(url));
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -35,6 +35,7 @@ import { toggleIngressVisibility } from './ingress/toggleIngressVisibility/toggl
 import { startStreamingLogs } from './logStream/startStreamingLogs';
 import { stopStreamingLogs } from './logStream/stopStreamingLogs';
 import { openConsoleInPortal } from './openConsoleInPortal';
+import { openExpressPortal } from './openExpressPortal';
 import { revealInEnvironment } from './revealInEnvironment';
 import { activateRevision } from './revision/activateRevision';
 import { chooseRevisionMode } from './revision/chooseRevisionMode/chooseRevisionMode';
@@ -67,6 +68,7 @@ export function registerCommands(): void {
     registerCommandWithTreeNodeUnwrapping('containerApps.deleteContainerApp', deleteContainerApp);
     registerCommandWithTreeNodeUnwrapping('containerApps.editContainerApp', editContainerApp);
     registerCommandWithTreeNodeUnwrapping('containerApps.openConsoleInPortal', openConsoleInPortal);
+    registerCommandWithTreeNodeUnwrapping('containerApps.openExpressPortal', openExpressPortal);
     registerCommandWithTreeNodeUnwrapping('containerApps.revealInEnvironment', revealInEnvironment);
     registerCommandWithTreeNodeUnwrapping('containerApps.toggleEnvironmentVariableVisibility',
         async (context: IActionContext, item: EnvironmentVariableItem) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,3 +91,6 @@ export const unsavedChangesTrueContextValue: string = 'unsavedChanges:true';
 export const unsavedChangesFalseContextValue: string = 'unsavedChanges:false';
 
 export const activityInfoContext: string = 'activity:info';
+
+export const expressContextValue: string = 'express';
+export const expressPortalBaseUrl: string = 'https://containerapps.azure.com/apps';

--- a/src/tree/ContainerAppItem.ts
+++ b/src/tree/ContainerAppItem.ts
@@ -11,7 +11,7 @@ import deepEqual from "deep-eql";
 import { TreeItemCollapsibleState, type TreeItem, type Uri } from "vscode";
 import { DeleteAllContainerAppsStep } from "../commands/deleteContainerApp/DeleteAllContainerAppsStep";
 import { type IDeleteContainerAppWizardContext } from "../commands/deleteContainerApp/IDeleteContainerAppWizardContext";
-import { revisionModeMultipleContextValue, revisionModeSingleContextValue, unsavedChangesFalseContextValue, unsavedChangesTrueContextValue } from "../constants";
+import { expressContextValue, revisionModeMultipleContextValue, revisionModeSingleContextValue, unsavedChangesFalseContextValue, unsavedChangesTrueContextValue } from "../constants";
 import { ext } from "../extensionVariables";
 import { createActivityContext } from "../utils/activityUtils";
 import { createContainerAppsAPIClient, createContainerAppsClient } from "../utils/azureClients";
@@ -47,7 +47,7 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
         return this._containerApp;
     }
 
-    constructor(public readonly subscription: AzureSubscription, private _containerApp: ContainerAppModel) {
+    constructor(public readonly subscription: AzureSubscription, private _containerApp: ContainerAppModel, public readonly isExpress: boolean = false) {
         this.id = this.containerApp.id;
         this.resourceGroup = this.containerApp.resourceGroup;
         this.name = this.containerApp.name;
@@ -67,6 +67,10 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
         values.push(this.containerApp.revisionsMode === KnownActiveRevisionsMode.Single ? revisionModeSingleContextValue : revisionModeMultipleContextValue);
         values.push(this.hasUnsavedChanges() ? unsavedChangesTrueContextValue : unsavedChangesFalseContextValue);
 
+        if (this.isExpress) {
+            values.push(expressContextValue);
+        }
+
         return createContextValue(values);
     }
 
@@ -77,6 +81,10 @@ export class ContainerAppItem implements ContainerAppsItem, RevisionsDraftModel 
 
         if (this.containerApp.provisioningState && this.containerApp.provisioningState !== 'Succeeded') {
             return this.containerApp.provisioningState;
+        }
+
+        if (this.isExpress) {
+            return localize('express', '(Express)');
         }
 
         return undefined;

--- a/src/tree/ManagedEnvironmentItem.ts
+++ b/src/tree/ManagedEnvironmentItem.ts
@@ -8,21 +8,26 @@ import { getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureut
 import { callWithTelemetryAndErrorHandling, createContextValue, createSubscriptionContext, nonNullProp, nonNullValueAndProp, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { type AzureResource, type AzureSubscription, type ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import { TreeItemCollapsibleState, type TreeItem } from "vscode";
-import { createContainerAppsAPIClient } from "../utils/azureClients";
+import { createContainerAppsAPIClient, createContainerAppsPreviewAPIClient } from "../utils/azureClients";
+import { localize } from "../utils/localize";
 import { treeUtils } from "../utils/treeUtils";
 import { ContainerAppItem } from "./ContainerAppItem";
 import { type ContainerAppsItem, type TreeElementBase } from "./ContainerAppsBranchDataProvider";
 
-type ManagedEnvironmentModel = ManagedEnvironment & ResourceModel;
+type ManagedEnvironmentModel = ManagedEnvironment & ResourceModel & {
+    environmentMode?: string;
+};
 
 export class ManagedEnvironmentItem implements TreeElementBase {
     static readonly contextValue: string = 'managedEnvironmentItem';
     static readonly contextValueRegExp: RegExp = new RegExp(ManagedEnvironmentItem.contextValue);
     viewProperties: ViewPropertiesModel;
     id: string;
+    readonly isExpress: boolean;
 
 
     constructor(public readonly subscription: AzureSubscription, public readonly resource: AzureResource, public readonly managedEnvironment: ManagedEnvironmentModel) {
+        this.isExpress = managedEnvironment.environmentMode === 'Express';
         this.id = managedEnvironment.id;
         this.viewProperties = {
             data: managedEnvironment,
@@ -53,7 +58,7 @@ export class ManagedEnvironmentItem implements TreeElementBase {
             context.valuesToMask.push(...containerApps.map(ca => ca.name), ...containerApps.map(ca => ca.id));
 
             return containerApps
-                .map(ca => new ContainerAppItem(this.subscription, ca))
+                .map(ca => new ContainerAppItem(this.subscription, ca, this.isExpress))
                 .sort((a, b) => treeUtils.sortById(a, b));
         });
 
@@ -63,6 +68,7 @@ export class ManagedEnvironmentItem implements TreeElementBase {
     getTreeItem(): TreeItem {
         return {
             label: this.managedEnvironment.name,
+            description: this.isExpress ? localize('express', '(Express)') : undefined,
             id: this.id,
             iconPath: treeUtils.getIconPath('managed-environment'),
             contextValue: this.contextValue,
@@ -84,8 +90,21 @@ export class ManagedEnvironmentItem implements TreeElementBase {
 
     static async Get(context: IActionContext, subscription: AzureSubscription, resourceGroup: string, name: string): Promise<ManagedEnvironmentModel> {
         const subContext = createSubscriptionContext(subscription);
-        const client: ContainerAppsAPIClient = await createContainerAppsAPIClient([context, subContext]);
-        return ManagedEnvironmentItem.CreateManagedEnvironmentModel(await client.managedEnvironments.get(resourceGroup, name));
+        const client: ContainerAppsAPIClient = await createContainerAppsPreviewAPIClient([context, subContext]);
+
+        let environmentMode: string | undefined;
+        const result = await client.managedEnvironments.get(resourceGroup, name, {
+            onResponse: (response) => {
+                const rawBody = response.bodyAsText;
+                if (rawBody) {
+                    environmentMode = (JSON.parse(rawBody) as { properties?: { environmentMode?: string } })?.properties?.environmentMode;
+                }
+            },
+        });
+
+        const model = ManagedEnvironmentItem.CreateManagedEnvironmentModel(result);
+        model.environmentMode = environmentMode;
+        return model;
     }
 
     private static CreateManagedEnvironmentModel(managedEnvironment: ManagedEnvironment): ManagedEnvironmentModel {

--- a/src/tree/scaling/ScaleItem.ts
+++ b/src/tree/scaling/ScaleItem.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { KnownActiveRevisionsMode, type Revision, type Scale } from "@azure/arm-appcontainers";
-import { createGenericElement, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { createGenericElement } from "@microsoft/vscode-azext-utils";
 import { type AzureSubscription, type ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import deepEqual from 'deep-eql';
 import { ThemeIcon, TreeItemCollapsibleState, type TreeItem } from "vscode";
@@ -50,12 +50,12 @@ export class ScaleItem extends RevisionDraftDescendantBase {
 
     protected setProperties(): void {
         this.label = scaling;
-        this.scale = nonNullValueAndProp(this.parentResource.template, 'scale');
+        this.scale = this.parentResource.template?.scale ?? {};
     }
 
     protected setDraftProperties(): void {
         this.label = `${scaling}*`;
-        this.scale = nonNullValueAndProp(ext.revisionDraftFileSystem.parseRevisionDraft(this), 'scale');
+        this.scale = ext.revisionDraftFileSystem.parseRevisionDraft(this)?.scale ?? {};
     }
 
     getTreeItem(): TreeItem {

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -24,6 +24,25 @@ export async function createContainerAppsAPIClient(context: AzExtClientContext):
     return createAzureClient(context, (await import('@azure/arm-appcontainers')).ContainerAppsAPIClient as unknown as AzExtClientType<ContainerAppsAPIClient>);
 }
 
+const previewApiVersion = '2026-03-02-preview';
+
+export async function createContainerAppsPreviewAPIClient(context: AzExtClientContext): Promise<ContainerAppsAPIClient> {
+    const client = await createContainerAppsAPIClient(context);
+    client.apiVersion = previewApiVersion;
+    client.pipeline.addPolicy({
+        name: 'PreviewApiVersionPolicy',
+        sendRequest(request, next) {
+            const [base, query] = request.url.split('?');
+            if (query) {
+                const newQuery = query.split('&').map(p => p.startsWith('api-version=') ? `api-version=${previewApiVersion}` : p).join('&');
+                request.url = `${base}?${newQuery}`;
+            }
+            return next(request);
+        },
+    });
+    return client;
+}
+
 export async function createContainerRegistryManagementClient(context: AzExtClientContext): Promise<ContainerRegistryManagementClient> {
     return createAzureClient(context, (await import('@azure/arm-containerregistry')).ContainerRegistryManagementClient);
 }


### PR DESCRIPTION
Azure Container Apps now supports Express environments, which have their own portal experience at `https://containerapps.azure.com`. This PR adds initial awareness of Express environments and apps to the extension's resource tree.

## Approach

- **Detecting Express environments:** The `environmentMode` property is only available in API version `2026-03-02-preview`, which the current SDK (`@azure/arm-appcontainers` v2.2.0) does not include. A preview API client factory (`createContainerAppsPreviewAPIClient`) overrides the API version via a pipeline policy. Because the SDK deserializer strips unknown properties, the raw HTTP response is captured via `onResponse` to extract `environmentMode`.

- **Visual distinction:** Express managed environments and their child container apps show `(Express)` as the tree item description.

- **"Open in Express Portal" command:** A new context menu command appears only on Express container apps (gated by an `express` context value). It opens the Express portal URL at `https://containerapps.azure.com/apps/{subscriptionId}/{resourceGroup}/{appName}/overview`.

- **Scale tolerance:** Express app templates may not include a `scale` property. `ScaleItem` now falls back to an empty object instead of throwing via `nonNullValueAndProp`, preventing errors when expanding Express app nodes.

## Non-obvious details

- The preview API version override works by adding a pipeline policy that rewrites the `api-version` query parameter on every request. This is necessary because the SDK's built-in `Parameters.apiVersion` is marked `isConstant: true` and ignores the client's `apiVersion` property during serialization.
- The `express` context value is only added to `ContainerAppItem` (not `ContainerAppResourceItem` in the flat view) since Express status is derived from the parent environment, which the flat view does not resolve.

Resolves #1077 